### PR TITLE
Allow pasing :method option to `field`

### DIFF
--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -37,6 +37,17 @@ shared_examples 'Base::render' do
     it('returns json with specified fields') { should eq(result) }
   end
 
+  context 'Given blueprint has ::field with a :method argument' do
+    let(:result) { '{"first_name":"Meg","identifier":' + obj_id + '}' }
+    let(:blueprint) do
+      Class.new(Blueprinter::Base) do
+        field :identifier, method: :id
+        field :first_name
+      end
+    end
+    it('returns json with a value assigned to the key') { should eq(result) }
+  end
+
   context 'Given blueprint has ::field with a :name argument' do
     let(:result) { '{"first_name":"Meg","identifier":' + obj_id + '}' }
     let(:blueprint) do


### PR DESCRIPTION
This change allows us to write our blueprints in terms of the JSON structure that we expect:

Before:
```ruby
class MyBlueprint < Blueprint::Base
  identifier :id
  field :name
  field :item_number, name: :position
end
```

After:
```ruby
class MyBlueprint < Blueprint::Base
  identifier :id
  field :name
  field :position, method: :item_number
end
```

Both blueprints would output
```json
{
  id: 1,
  name: "A name",
  position: 123
}
```

I think the latter method seems preferable and more readable as it reflects what keys are supposed to show up in the JSON result.

This change should not break existing blueprint structures; it just allows more flexibility for those who prefer to write their blueprints the way that they expect the JSON object should appear.