### PR TITLE
Raise Blueprinter Error for invalid empty types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0  - `<RELEASE_DATE>`
+### Major Release
+*💥 [BREAKING] Raise `Blueprinter::BlueprinterError` when `default_if` is passed an invalid empty type.
+See [#]()
+
 ## 0.25.1  - 2020/8/18
 * 🚀 [BUGFIX] Raise Blueprinter::BlueprinterError if Blueprint given is not of class Blueprinter::Base. Before it just raised a generic `undefined method 'prepare'`. See [#233](https://github.com/procore/blueprinter/pull/233) thanks to [@caws](https://github.com/caws)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.0.0  - `<RELEASE_DATE>`
 ### Major Release
 *💥 [BREAKING] Raise `Blueprinter::BlueprinterError` when `default_if` is passed an invalid empty type.
-See [#]()
+See [#242](https://github.com/procore/blueprinter/pull/242)
 
 ## 0.25.1  - 2020/8/18
 * 🚀 [BUGFIX] Raise Blueprinter::BlueprinterError if Blueprint given is not of class Blueprinter::Base. Before it just raised a generic `undefined method 'prepare'`. See [#233](https://github.com/procore/blueprinter/pull/233) thanks to [@caws](https://github.com/caws)

--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ end
 
 Sometimes, you may want certain "empty" values to pass through to the default value.
 Blueprinter provides the ability to treat the following empty types as the default value (or `nil` if no default provided).
+_NOTE:_ A `Blueprinter::Error` is raised if an invalid empty type is passed.
 
 #### Blueprinter::EMPTY_COLLECTION
 An empty array or empty active record collection.

--- a/lib/blueprinter/empty_types.rb
+++ b/lib/blueprinter/empty_types.rb
@@ -10,6 +10,8 @@ module Blueprinter
     private
 
     def use_default_value?(value, empty_type)
+      return value.nil? unless empty_type
+
       case empty_type
       when Blueprinter::EMPTY_COLLECTION
         array_like?(value) && value.empty?
@@ -18,7 +20,7 @@ module Blueprinter
       when Blueprinter::EMPTY_STRING
         value.to_s == ""
       else
-        value.nil?
+        raise BlueprinterError, "Invalid empty type '#{empty_type}' received. Must be one of [nil, Blueprinter::EMPTY_COLLECTION, Blueprinter::EMPTY_HASH, Blueprinter::EMPTY_STRING]"
       end
     end
   end

--- a/lib/blueprinter/version.rb
+++ b/lib/blueprinter/version.rb
@@ -1,3 +1,3 @@
 module Blueprinter
-  VERSION = '0.25.1'.freeze
+  VERSION = '1.0.0'.freeze
 end

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -171,6 +171,18 @@ shared_examples 'Base::render' do
     it('uses the correct default values') { should eq(result) }
   end
 
+  context 'Given default_if option is invalid' do
+    let(:blueprint) do
+      Class.new(Blueprinter::Base) do
+        field :id
+        field :first_name, default_if: "INVALID_EMPTY_TYPE", default: "Unknown"
+      end
+    end
+    it('raises a BlueprinterError') {
+      expect{blueprint.render(obj)}.to raise_error(Blueprinter::BlueprinterError)
+    }
+  end
+
   context "Given blueprint has ::field with nil value" do
     before do
       obj[:first_name] = nil


### PR DESCRIPTION
*💥 [BREAKING] Raise `Blueprinter::BlueprinterError` when `default_if` is passed an invalid empty type.

### Closes Issue:
https://github.com/procore/blueprinter/issues/241