### PR TITLE
feature: render default view instead of raising error if view is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,6 +868,44 @@ Output:
 ---
 </details>
 
+<details>
+<summary>Missing Views</summary>
+
+---
+
+By default a BlueprinterError is raised if you call a view that doesn't exist. This is troublesome in some cases while using polymorphic relationships.
+If you set this config to `:default` it will render the default view instead of raising an error.
+
+Usage:
+
+```ruby
+Blueprinter.configure do |config|
+  config.missing_view = :default
+end
+```
+
+```ruby
+class UserBlueprint < Blueprinter::Base
+  identifier :name
+  field :email
+  field :birthday, datetime_format: "%m/%d/%Y"
+end
+
+
+puts UserBlueprint.render(user, view: :non_existant_view)
+```
+
+Output:
+```json
+{
+  "name": "John Doe",
+  "email": "john.doe@some.fake.email.domain",
+  "birthday": "03/04/1994"
+}
+```
+
+---
+</details>
 
 <details>
 <summary>Deprecations</summary>

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -253,7 +253,11 @@ module Blueprinter
     # @api private
     def self.prepare(object, view_name:, local_options:, root: nil, meta: nil)
       unless view_collection.has_view? view_name
-        raise BlueprinterError, "View '#{view_name}' is not defined"
+        if Blueprinter.configuration.missing_view.eql?(:default)
+          view_name = :default
+        else
+          raise BlueprinterError, "View '#{view_name}' is not defined"
+        end
       end
 
       data = prepare_data(object, view_name, local_options)

--- a/lib/blueprinter/configuration.rb
+++ b/lib/blueprinter/configuration.rb
@@ -1,6 +1,6 @@
 module Blueprinter
   class Configuration
-    attr_accessor :association_default, :datetime_format, :deprecations, :field_default, :generator, :if, :method, :sort_fields_by, :unless, :extractor_default, :default_transformers
+    attr_accessor :association_default, :datetime_format, :deprecations, :field_default, :generator, :if, :method, :sort_fields_by, :unless, :missing_view, :extractor_default, :default_transformers
 
     VALID_CALLABLES = %i(if unless).freeze
 
@@ -14,6 +14,7 @@ module Blueprinter
       @method = :generate
       @sort_fields_by = :name_asc
       @unless = nil
+      @missing_view = nil
       @extractor_default = AutoExtractor
       @default_transformers = []
     end


### PR DESCRIPTION
I was having trouble with missing views while using polymorphic relationships and transformers.
I've added this new configuration to prevent an error being raised and instead using the default view if a view is not defined

this is related to my issue #228 