### PR TITLE
Feature proposal: Support tolerating rendering `nil`

### DIFF
--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -183,6 +183,8 @@ module Blueprinter
     # @option options [Any] :meta Defaults to nil.
     #   Render the json/hash with a meta attribute with provided value
     #   if both root and meta keys are provided in the options hash.
+    # @option options [Symbol] :allow_nil Defaults to false
+    #   Allow the rendering of nil object as NULL.
     #
     # @example Generating JSON with an extended view
     #   post = Post.all

--- a/lib/blueprinter/helpers/base_helpers.rb
+++ b/lib/blueprinter/helpers/base_helpers.rb
@@ -18,6 +18,9 @@ module Blueprinter
       end
 
       def prepare_data(object, view_name, local_options)
+        allow_nil = local_options.delete(:allow_nil)
+        return if allow_nil && object.nil?
+
         if array_like?(object)
           object.map do |obj|
             object_to_hash(obj,

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -736,4 +736,24 @@ shared_examples 'Base::render' do
       should(eq(excluded_view_keys))
     end
   end
+
+  context 'allowing nil object' do
+    let(:blueprint) do
+      Class.new(Blueprinter::Base) do
+        field :id
+      end
+    end
+
+    it 'renders nil' do
+      pending
+      result = blueprint.render(nil, allow_nil: true)
+      expect(result).to eq('null')
+    end
+
+    it 'renders nil with root' do
+      pending
+      result = blueprint.render(nil, root: :root, allow_nil: true)
+      expect(result).to eq('{"root":null}')
+    end
+  end
 end

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -745,13 +745,11 @@ shared_examples 'Base::render' do
     end
 
     it 'renders nil' do
-      pending
       result = blueprint.render(nil, allow_nil: true)
       expect(result).to eq('null')
     end
 
     it 'renders nil with root' do
-      pending
       result = blueprint.render(nil, root: :root, allow_nil: true)
       expect(result).to eq('{"root":null}')
     end


### PR DESCRIPTION
# Problem

I have found that I have some use case for rendering potentially-nil values. In particular, this is when I wish to specify a `:root` on the rendering:

```ruby
WidgetBlueprint.render(widget_or_nil, root: :widget)
```

When the value of `widget_or_nil` is `nil`, the following error occurs:
```
NoMethodError: undefined method `id' for nil:NilClass
```

To solve this problem today, we have to resort to wrapping the result outside the use of the library. Something like:
```ruby
{ widget: widget_or_nil && WidgetBlueprint.render(widget_or_nil) }
```

This isn't _the worst_, but it's a little repetitive.

# Proposal

Given the stated Problem, I am proposing a new rendering option `:allow_nil` that solves this problem. I chose the name based on similar options seen [in Ruby on Rails](https://api.rubyonrails.org/classes/ActiveRecord/Validations/ClassMethods.html). It would work like this:

```ruby
widget_or_nil = Widget.new(id: 123)
rendered = WidgetBlueprint.render_as_hash(widget_or_nil, root: :widget)
# => { widget: { id: 123 } }

widget_or_nil = nil
rendered = WidgetBlueprint.render_as_hash(widget_or_nil, root: :widget)
# => { widget: nil }
```

# A Note on `nil`

I recognize that this my be a controversial proposal based on the prevalence of issues caused by `nil` in systems. That said, I believe the use case is legitimate, and it feels a little icky to me to have to ditch the library-support `:root` feature for such a case.

Either way, I'm entirely open to feedback and appreciate you having a look at this!