### PR TITLE
Fix render resources with the same options

### DIFF
--- a/lib/blueprinter/helpers/base_helpers.rb
+++ b/lib/blueprinter/helpers/base_helpers.rb
@@ -10,6 +10,7 @@ module Blueprinter
       private
 
       def prepare_for_render(object, options)
+        options = options.dup
         view_name = options.delete(:view) || :default
         root = options.delete(:root)
         meta = options.delete(:meta)

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -391,6 +391,28 @@ describe '::Base' do
         it 'returns a hash with expected format' do
           expect(subject).to eq({ id: obj.id, position_and_company: "#{obj.position} at #{obj.company}"})
         end
+
+        context 'with the same options' do
+          let(:blueprint) do
+            Class.new(Blueprinter::Base) do
+              identifier :id
+
+              field :first_name
+
+              view :with_last_name do
+                field :last_name
+              end
+            end
+          end
+          let(:options) { { view: :with_last_name } }
+          let(:expected_result) do
+            { id: obj.id, first_name: obj.first_name, last_name: obj.last_name }
+          end
+
+          it 'renders several objects with the same options' do
+            expect(blueprint.render_as_hash(obj, options)).to eq(expected_result)
+            expect(blueprint.render_as_hash(obj, options)).to eq(expected_result)
+          end
       end
     end
   end
@@ -402,6 +424,29 @@ describe '::Base' do
         let(:obj) { object_with_attributes }
         it 'returns a hash with expected format' do
           expect(subject).to eq({ "id" => obj.id, "position_and_company" => "#{obj.position} at #{obj.company}"})
+        end
+
+        context 'with the same options' do
+          let(:blueprint) do
+            Class.new(Blueprinter::Base) do
+              identifier :id
+
+              field :first_name
+
+              view :with_last_name do
+                field :last_name
+              end
+            end
+          end
+          let(:options) { { view: :with_last_name } }
+          let(:expected_result) do
+            { 'id' => obj.id, 'first_name' => obj.first_name, 'last_name' => obj.last_name }
+          end
+
+          it 'renders several objects with the same options' do
+            expect(blueprint.render_as_json(obj, options)).to eq(expected_result)
+            expect(blueprint.render_as_json(obj, options)).to eq(expected_result)
+          end
         end
       end
     end

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -419,6 +419,15 @@ shared_examples 'Base::render' do
       expect(blueprint.render(obj, view: :special)).to    eq(special)
       expect(blueprint.render(obj)).to                    eq(no_view)
     end
+
+    context 'with the same options' do
+      let(:options) { { view: :normal } }
+
+      it 'renders several objects with the same options' do
+        expect(blueprint.render(obj, options)).to eq(normal)
+        expect(blueprint.render(obj, options)).to eq(normal)
+      end
+    end
   end
 
   context 'Given blueprint has :root' do


### PR DESCRIPTION
The problem is that `delete` removes keys from the `original options`.
**Example:**
```ruby
options = { view: :some_view }
resources.each do |resource|
  serializer.render_as_hash(resource, **options)
end
```
Only the first resource will be rendered with the "view" param.