### PR TITLE
Feature proposal: Honor all conditional checks config - path for sparse fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,7 +670,7 @@ Output:
 
 
 Both the `field` and the global Blueprinter Configuration supports `:if` and `:unless` options that can be used to serialize fields conditionally.
-By default, field-level conditions override global conditions. By enabling `roll_up_conditions`, BOTH field-level and global conditions must be met in order for the field to be serialized.
+By default, field-level conditions override global conditions. By enabling `enforce_all_conditions`, BOTH field-level and global conditions must be met in order for the field to be serialized.
 
 ### Global Config Setting - if and unless
 
@@ -678,7 +678,7 @@ By default, field-level conditions override global conditions. By enabling `roll
 Blueprinter.configure do |config|
   config.if = ->(field_name, obj, _options) { !obj[field_name].nil? }
   config.unless = ->(field_name, obj, _options) { obj[field_name].nil? }
-  config.roll_up_conditions = true
+  config.enforce_all_conditions = true
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -670,7 +670,7 @@ Output:
 
 
 Both the `field` and the global Blueprinter Configuration supports `:if` and `:unless` options that can be used to serialize fields conditionally.
-By default field-level conditions override global conditions. By enabling `roll_up_conditions`, BOTH field-level and global conditions must be met in order for field to be serialized.
+By default, field-level conditions override global conditions. By enabling `roll_up_conditions`, BOTH field-level and global conditions must be met in order for the field to be serialized.
 
 ### Global Config Setting - if and unless
 

--- a/README.md
+++ b/README.md
@@ -670,6 +670,7 @@ Output:
 
 
 Both the `field` and the global Blueprinter Configuration supports `:if` and `:unless` options that can be used to serialize fields conditionally.
+By default field-level conditions override global conditions. By enabling `roll_up_conditions`, BOTH field-level and global conditions must be met in order for field to be serialized.
 
 ### Global Config Setting - if and unless
 
@@ -677,6 +678,7 @@ Both the `field` and the global Blueprinter Configuration supports `:if` and `:u
 Blueprinter.configure do |config|
   config.if = ->(field_name, obj, _options) { !obj[field_name].nil? }
   config.unless = ->(field_name, obj, _options) { obj[field_name].nil? }
+  config.roll_up_conditions = true
 end
 ```
 
@@ -690,8 +692,7 @@ class UserBlueprint < Blueprinter::Base
 end
 ```
 
-_NOTE:_ The field-level setting overrides the global config setting (for the field) if both are set.
-
+---
 </details>
 
 <details>

--- a/lib/blueprinter/configuration.rb
+++ b/lib/blueprinter/configuration.rb
@@ -3,7 +3,8 @@
 module Blueprinter
   class Configuration
     attr_accessor :association_default, :datetime_format, :deprecations, :field_default, :generator, :if, :method,
-                  :sort_fields_by, :unless, :extractor_default, :default_transformers, :custom_array_like_classes
+                  :sort_fields_by, :unless, :extractor_default, :default_transformers, :custom_array_like_classes,
+                  :roll_up_conditions
 
     VALID_CALLABLES = %i[if unless].freeze
 
@@ -20,6 +21,7 @@ module Blueprinter
       @extractor_default = AutoExtractor
       @default_transformers = []
       @custom_array_like_classes = []
+      @roll_up_conditions = false
     end
 
     def array_like_classes

--- a/lib/blueprinter/configuration.rb
+++ b/lib/blueprinter/configuration.rb
@@ -4,7 +4,7 @@ module Blueprinter
   class Configuration
     attr_accessor :association_default, :datetime_format, :deprecations, :field_default, :generator, :if, :method,
                   :sort_fields_by, :unless, :extractor_default, :default_transformers, :custom_array_like_classes,
-                  :roll_up_conditions
+                  :enforce_all_conditions
 
     VALID_CALLABLES = %i[if unless].freeze
 
@@ -21,7 +21,7 @@ module Blueprinter
       @extractor_default = AutoExtractor
       @default_transformers = []
       @custom_array_like_classes = []
-      @roll_up_conditions = false
+      @enforce_all_conditions = false
     end
 
     def array_like_classes

--- a/lib/blueprinter/field.rb
+++ b/lib/blueprinter/field.rb
@@ -18,7 +18,7 @@ module Blueprinter
     end
 
     def skip?(field_name, object, local_options)
-      if Blueprinter.configuration.roll_up_conditions
+      if Blueprinter.configuration.enforce_all_conditions
         any_global_or_field_condition_failed?(field_name, object, local_options)
       else
         return true if if_callable && !if_callable.call(field_name, object, local_options)

--- a/lib/blueprinter/field.rb
+++ b/lib/blueprinter/field.rb
@@ -45,7 +45,6 @@ module Blueprinter
       [
         extract_callable_from(Blueprinter.configuration.if),
         extract_callable_from(options[:if])
-
       ].select { |callable| callable }
     end
 

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -334,11 +334,11 @@ shared_examples 'Base::render' do
               end
             end
 
-            context 'roll_up_conditions is enabled' do
+            context 'enforce_all_conditions is enabled' do
               let(:local_options) { {x: 1, y: 2, v1: value, v2: other_value} }
 
               before do
-                Blueprinter.configuration.roll_up_conditions = true
+                Blueprinter.configuration.enforce_all_conditions = true
                 Blueprinter.configuration.if = ->(field_name, object, local_opts) {
                   if local_opts[:sparse_fields]
                     local_opts[:sparse_fields].include?(field_name.to_s)
@@ -349,7 +349,7 @@ shared_examples 'Base::render' do
                 Blueprinter.configuration.unless = ->(_a,_b,_c) { other_value }
               end
               after do
-                Blueprinter.configuration.roll_up_conditions = false
+                Blueprinter.configuration.enforce_all_conditions = false
                 Blueprinter.configuration.if = nil
                 Blueprinter.configuration.unless = nil
               end


### PR DESCRIPTION
#### Background
At my company we make liberal use of views. But there are times that I find them constricting when trying to optimize payload sizes. I would like to have more granular control over what is returned. I propose adding a configuration to honor all conditional checks. This would allow for a lightweight implementation for sparse fields support over our API.

Example:
```ruby
Blueprinter.configure do |config|
  config.roll_up_conditions = true
  config.if = ->(field_name, object, local_opts) {
    if local_opts[:sparse_fields]
      local_opts[:sparse_fields].any? { |sfield| sfield.to_s == field_name.to_s }
    else
      true
    end
  }
end

class SlothBlueprint < Blueprinter::Base
  identifier :uuid

  field :name
  field :favorite_food
  field :hair_color
  field :sunglasses, name: :has_sunglasses
end

class Sloth
  attr_accessor :name, :favorite_food, :hair_color, :sunglasses
  def initialize(name, food, color, sg)
    @name = name
    @favorite_food = food
    @hair_color = color
    @sunglasses = sg
  end

  def uuid
    Random.new_seed.to_s
  end
end

my_sloth = Sloth.new('Mirabel', 'bananas', 'brown', true)

SlothBlueprint.render_as_hash(my_sloth, sparse_fields: [:has_sunglasses, :favorite_food])
# => {:favorite_food => 'bananas', :has_sunglasses => true }

SlothBlueprint.render_as_hash(my_sloth)
# => {:uuid => '21342134...', :favorite_food => 'bananas', :hair_color => 'brown', :has_sunglasses => true, :name => 'Mirabel'}
```

Checklist:

* [X] I have updated the necessary documentation
* [ ] I have updated the changelog, if necessary (CHANGELOG.md)
* [X] I have signed off all my commits as required by [DCO](../CONTRIBUTING.md#legal)
* [X] My build is green

