### PR TITLE
chore: add stale github action

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,38 @@
+## Reference: https://github.com/actions/stale
+name: Mark stale issues and pull requests
+on:
+  schedule:
+  - cron: "30 1 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@b69b346013879cedbf50c69f572cd85439a41936 # (latest, untagged)
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Number of days of inactivity before an issue becomes stale
+        days-before-stale: 60
+        # Number of days of inactivity before a stale issue is closed
+        days-before-close: 7
+        # Issues with these labels will never be considered stale
+        exempt-issue-labels: "on-hold,pinned,security"
+        exempt-pr-labels: "on-hold,pinned,security"
+        # Comment to post when marking an issue as stale.
+        stale-issue-message: >
+          This issue has been automatically marked as stale because it has not had
+          recent activity. It will be closed if no further activity occurs. Thank you
+          for your contributions.
+        stale-pr-message: >
+          This pull request has been automatically marked as stale because it has not had
+          recent activity. It will be closed if no further activity occurs. Thank you
+          for your contributions.
+        # Label to use when marking an issue as stale
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'


### PR DESCRIPTION
We are actively working through issues and pull requests.

Once done, we can add this and allow for automation of issues/PRs being marked stale/closed

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->

Checklist:

* [ ] I have updated the necessary documentation
* [ ] I have updated the changelog, if necessary (CHANGELOG.md)
* [x] I have signed off all my commits as required by [DCO](../CONTRIBUTING.md#legal)
* [x] My build is green
