### PR TITLE
fix: github url in files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Test](https://github.com/procore/blueprinter/actions/workflows/test.yaml/badge.svg?branch=master)](https://github.com/procore/blueprinter/actions/workflows/test.yaml)
+[![Test](https://github.com/procore-oss/blueprinter/actions/workflows/test.yaml/badge.svg?branch=master)](https://github.com/procore-oss/blueprinter/actions/workflows/test.yaml)
 [![Gem Version](https://badge.fury.io/rb/blueprinter.svg)](https://badge.fury.io/rb/blueprinter)
 [![Gitter chat](https://badges.gitter.im/procore/blueprinter.svg)](https://gitter.im/blueprinter-gem/community)
 

--- a/blueprinter.gemspec
+++ b/blueprinter.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.version     = Blueprinter::VERSION
   s.authors     = ['Adam Hess', 'Derek Carter']
   s.email       = ['blueprinter@googlegroups.com']
-  s.homepage    = 'https://github.com/procore/blueprinter'
+  s.homepage    = 'https://github.com/procore-oss/blueprinter'
   s.summary     = 'Simple Fast Declarative Serialization Library'
   s.description = 'Blueprinter is a JSON Object Presenter for Ruby that takes business objects and breaks them down into simple hashes and serializes them to JSON. It can be used in Rails in place of other serializers (like JBuilder or ActiveModelSerializers). It is designed to be simple, direct, and performant.'
   s.license     = 'MIT'


### PR DESCRIPTION
change from github.com/procore/blueprinter to github.com/procore-oss/blueprinter

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->

Checklist:

* [ ] I have updated the necessary documentation
* [ ] I have updated the changelog, if necessary (CHANGELOG.md)
* [x] I have signed off all my commits as required by [DCO](../CONTRIBUTING.md#legal)
* [x] My build is green
