### PR TITLE
Release 0.26.0 to drop ruby < 2.7 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 0.26.0  - 2023/00/00
-* 🐛 [FEATURE] Transition to GitHub Actions from CircleCI and update to handle Ruby versions 2.7, 3.0, 3.1, 3.2
+## 0.26.0  - 2023/08/17
+* 🐛 [BREAKING] Transition to GitHub Actions from CircleCI and update to handle Ruby versions 2.7, 3.0, 3.1, 3.2. Drop support for any ruby version less than 2.7. See [#307](https://github.com/procore-oss/blueprinter/pull/307)
 
 ## 0.25.3  - 2021/03/03
 * 🐛 [BUGFIX] Fixes issue where fields and associations that are redefined by later views were not properly overwritten. See [#201](https://github.com/procore/blueprinter/pull/201) thanks to [@Berardpi](https://github.com/Berardpi).

--- a/lib/blueprinter/version.rb
+++ b/lib/blueprinter/version.rb
@@ -1,3 +1,3 @@
 module Blueprinter
-  VERSION = '0.25.3'.freeze
+  VERSION = '0.26.0'.freeze
 end


### PR DESCRIPTION
Release 0.26.0 to drop ruby < 2.7 support

This releases the gem to 0.26.0. It drops support for any ruby version less than 2.7. See #307