### PR TITLE
fix: change release github action to use different actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,10 +4,11 @@ on:
     workflows: [Test]
     types: [completed]
     branches: [master, main]
+  workflow_dispatch: # allow manual deployment through GitHub Action UI
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # (latest, untagged)
       - name: Version file changed
@@ -15,10 +16,20 @@ jobs:
         uses: tj-actions/changed-files@76c4d81a6acd339b55bd7407a016981c853eb702 # (latest, untagged)
         with:
           files: lib/blueprinter/version.rb
-      - name: Release New Gem Version
-        if: ${{ steps.version-file-changed.outputs.any_changed == 'true' }}
-        uses: cadwallion/publish-rubygems-action@94a6f4cd5350581749c569b5001eecc864e3ad0b # (latest, untagged)
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          RUBYGEMS_API_KEY: ${{secrets.RUBY_GEMS_API_KEY}}
-          RELEASE_COMMAND: bundle exec rake release || true # Don't fail when deploy does not take place
+      - name: Set up Ruby
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.version-file-changed.outputs.any_changed == 'true' }}
+        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # (latest, untagged)
+        with:
+          ruby-version: 3.2
+          bundler-cache: true
+      - name: Installing dependencies
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.version-file-changed.outputs.any_changed == 'true' }}
+        run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
+      - uses: fac/ruby-gem-setup-credentials-action@5f62d5f2f56a11c7422a92f81fbb29af01e1c00f # (latest, untagged)
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.version-file-changed.outputs.any_changed == 'true' }}
+        with:
+          user: ""
+          key: rubygems
+          token: ${{secrets.RUBY_GEMS_API_KEY}}
+      - uses: fac/ruby-gem-push-action@81d77bf568ff6659d7fae0f0c5a036bb0aeacb1a # (latest, untagged)
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.version-file-changed.outputs.any_changed == 'true' }}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->

Checklist:

* [ ] I have updated the necessary documentation
* [ ] I have updated the changelog, if necessary (CHANGELOG.md)
* [x] I have signed off all my commits as required by [DCO](../CONTRIBUTING.md#legal)
* [ ] My build is green
