### PR TITLE
fix: release fixes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,3 +33,5 @@ jobs:
           token: ${{secrets.RUBY_GEMS_API_KEY}}
       - uses: fac/ruby-gem-push-action@81d77bf568ff6659d7fae0f0c5a036bb0aeacb1a # (latest, untagged)
         if: ${{ github.event_name == 'workflow_dispatch' || steps.version-file-changed.outputs.any_changed == 'true' }}
+        with:
+          key: rubygems

--- a/blueprinter.gemspec
+++ b/blueprinter.gemspec
@@ -7,12 +7,13 @@ require 'blueprinter/version'
 Gem::Specification.new do |s|
   s.name        = 'blueprinter'
   s.version     = Blueprinter::VERSION
-  s.authors     = ['Adam Hess', 'Derek Carter']
+  s.authors     = ['Derek Carter']
   s.email       = ['blueprinter@googlegroups.com']
   s.homepage    = 'https://github.com/procore-oss/blueprinter'
   s.summary     = 'Simple Fast Declarative Serialization Library'
   s.description = 'Blueprinter is a JSON Object Presenter for Ruby that takes business objects and breaks them down into simple hashes and serializes them to JSON. It can be used in Rails in place of other serializers (like JBuilder or ActiveModelSerializers). It is designed to be simple, direct, and performant.'
   s.license     = 'MIT'
+  s.metadata['allowed_push_host'] = 'https://rubygems.org'
 
   s.files = Dir['{app,config,db,lib}/**/*', 'CHANGELOG.md', 'MIT-LICENSE', 'Rakefile', 'README.md']
 


### PR DESCRIPTION
- [x] remove Adam Hess from authors list (he is in Emeritus.md)
- [x] add allowed_push_host to gemspec (error in GitHub action [here](https://github.com/procore-oss/blueprinter/actions/runs/6224839827/job/16893930265#step:7:17)
- [x] add key to release gem action to match the key we setup in previous step (rubygems)

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->

Checklist:

* [ ] I have updated the necessary documentation
* [ ] I have updated the changelog, if necessary (CHANGELOG.md)
* [x] I have signed off all my commits as required by [DCO](../CONTRIBUTING.md#legal)
* [ ] My build is green
