### PR TITLE
Removes Gitter Link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Test](https://github.com/procore-oss/blueprinter/actions/workflows/test.yaml/badge.svg?branch=master)](https://github.com/procore-oss/blueprinter/actions/workflows/test.yaml)
 [![Gem Version](https://badge.fury.io/rb/blueprinter.svg)](https://badge.fury.io/rb/blueprinter)
-[![Gitter chat](https://badges.gitter.im/procore/blueprinter.svg)](https://gitter.im/blueprinter-gem/community)
 
 <img src="blueprinter_logo.svg" width="25%">
 


### PR DESCRIPTION
## Background
We currently have a link to a Gitter forum in the README that's not intentionally used/maintained at the moment. While we're still discussing community communication options moving forward, we'd like to remove the link to avoid any confusion until a decision can be made. 

## Changelog
- Removes Gitter link from README

Checklist:

* [ ] I have updated the necessary documentation
* [ ] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [ ] My build is green
