### PR TITLE
Add Discord Link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Test](https://github.com/procore-oss/blueprinter/actions/workflows/test.yaml/badge.svg?branch=master)](https://github.com/procore-oss/blueprinter/actions/workflows/test.yaml)
 [![Gem Version](https://badge.fury.io/rb/blueprinter.svg)](https://badge.fury.io/rb/blueprinter)
+[![Discord](https://raw.githubusercontent.com/procore-oss/.github/main/discord_badge_scaled.svg)](https://discord.gg/PbntEMmWws)
 
 <img src="blueprinter_logo.svg" width="25%">
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Test](https://github.com/procore-oss/blueprinter/actions/workflows/test.yaml/badge.svg?branch=master)](https://github.com/procore-oss/blueprinter/actions/workflows/test.yaml)
 [![Gem Version](https://badge.fury.io/rb/blueprinter.svg)](https://badge.fury.io/rb/blueprinter)
-[![Discord](https://raw.githubusercontent.com/procore-oss/.github/main/discord_badge_scaled.svg)](https://discord.gg/PbntEMmWws)
+[![Discord](https://img.shields.io/badge/Chat-EDEDED?logo=discord)](https://discord.gg/PbntEMmWws)
 
 <img src="blueprinter_logo.svg" width="25%">
 


### PR DESCRIPTION
## Changelog
- Add invite link to #blueprinter Discord channel in README. 

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [x] My build is green
