### PR TITLE
Add reflection on views, fields, and associations

### DIFF
--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -17,10 +17,12 @@ require_relative 'helpers/base_helpers'
 require_relative 'view'
 require_relative 'view_collection'
 require_relative 'transformer'
+require_relative 'reflection'
 
 module Blueprinter
   class Base
     include BaseHelpers
+    extend Reflection
 
     # Specify a field or method name used as an identifier. Usually, this is
     # something like :id

--- a/lib/blueprinter/reflection.rb
+++ b/lib/blueprinter/reflection.rb
@@ -74,7 +74,10 @@ module Blueprinter
 
       # Returns all fields or associations from included views
       def included(type)
-        @view.included_view_names.reduce({}) do |acc, view_name|
+        view_names = @view.included_view_names
+        view_names.unshift :default unless name == :default
+
+        view_names.reduce({}) do |acc, view_name|
           view = @blueprint.reflections.fetch(view_name)
           acc.merge view.send(type)
         end

--- a/lib/blueprinter/reflection.rb
+++ b/lib/blueprinter/reflection.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Blueprinter
+  #
+  # Public methods for reflecting on a Blueprint.
+  #
+  module Reflection
+    #
+    # Returns a Hash of views keyed by name.
+    #
+    # Example:
+    #
+    #   widget_view = WidgetBlueprint.views[:default]
+    #   category = widget_view.associations[:category]
+    #   category.blueprint
+    #   => CategoryBlueprint
+    #   category.view
+    #   => :default
+    #
+    # @return [Hash<Symbol, Blueprinter::Reflection::View>]
+    #
+    def views
+      @views ||= view_collection.views.transform_values do |view|
+        View.new(self, view)
+      end
+    end
+
+    #
+    # Represents a view within a Blueprint.
+    #
+    class View
+      Field = Struct.new(:name, :display_name, :options)
+      Association = Struct.new(:name, :display_name, :blueprint, :view, :options)
+
+      def initialize(blueprint, view)
+        @blueprint = blueprint
+        @view = view
+      end
+
+      # @return [String] The view's name
+      def name
+        @view.name
+      end
+
+      #
+      # Returns a Hash of fields in this view (recursive) keyed by method name.
+      #
+      # @return [Hash<Symbol, Blueprinter::Reflection::View::Field>]
+      #
+      def fields
+        @fields ||= @view.fields.each_with_object(included(:fields)) do |(_name, field), obj|
+          unless field.options[:association] # rubocop:todo Style/IfUnlessModifier
+            obj[field.method] = Field.new(field.method, field.name, field.options)
+          end
+        end
+      end
+
+      #
+      # Returns a Hash of associations in this view (recursive) keyed by method name.
+      #
+      # @return [Hash<Symbol, Blueprinter::Reflection::View::Association>]
+      #
+      def associations
+        @associations ||= @view.fields.each_with_object(included(:associations)) do |(_name, field), obj|
+          next unless field.options[:association]
+
+          blueprint = field.options.fetch(:blueprint)
+          view = field.options[:view] || :default
+          obj[field.method] = Association.new(field.method, field.name, blueprint, view, field.options)
+        end
+      end
+
+      private
+
+      # Recursively returns all fields or associations from included views
+      def included(type)
+        @view.included_view_names.reduce({}) do |acc, view_name|
+          view = @blueprint.views.fetch(view_name)
+          acc.merge view.send(type)
+        end
+      end
+    end
+  end
+end

--- a/lib/blueprinter/reflection.rb
+++ b/lib/blueprinter/reflection.rb
@@ -5,12 +5,15 @@ module Blueprinter
   # Public methods for reflecting on a Blueprint.
   #
   module Reflection
+    Field = Struct.new(:name, :display_name, :options)
+    Association = Struct.new(:name, :display_name, :blueprint, :view, :options)
+
     #
     # Returns a Hash of views keyed by name.
     #
     # Example:
     #
-    #   widget_view = WidgetBlueprint.views[:default]
+    #   widget_view = WidgetBlueprint.reflections[:default]
     #   category = widget_view.associations[:category]
     #   category.blueprint
     #   => CategoryBlueprint
@@ -19,8 +22,8 @@ module Blueprinter
     #
     # @return [Hash<Symbol, Blueprinter::Reflection::View>]
     #
-    def views
-      @views ||= view_collection.views.transform_values do |view|
+    def reflections
+      @reflections ||= view_collection.views.transform_values do |view|
         View.new(self, view)
       end
     end
@@ -29,9 +32,6 @@ module Blueprinter
     # Represents a view within a Blueprint.
     #
     class View
-      Field = Struct.new(:name, :display_name, :options)
-      Association = Struct.new(:name, :display_name, :blueprint, :view, :options)
-
       def initialize(blueprint, view)
         @blueprint = blueprint
         @view = view
@@ -45,7 +45,7 @@ module Blueprinter
       #
       # Returns a Hash of fields in this view (recursive) keyed by method name.
       #
-      # @return [Hash<Symbol, Blueprinter::Reflection::View::Field>]
+      # @return [Hash<Symbol, Blueprinter::Reflection::Field>]
       #
       def fields
         @fields ||= @view.fields.each_with_object(included(:fields)) do |(_name, field), obj|
@@ -58,7 +58,7 @@ module Blueprinter
       #
       # Returns a Hash of associations in this view (recursive) keyed by method name.
       #
-      # @return [Hash<Symbol, Blueprinter::Reflection::View::Association>]
+      # @return [Hash<Symbol, Blueprinter::Reflection::Association>]
       #
       def associations
         @associations ||= @view.fields.each_with_object(included(:associations)) do |(_name, field), obj|
@@ -72,10 +72,10 @@ module Blueprinter
 
       private
 
-      # Recursively returns all fields or associations from included views
+      # Returns all fields or associations from included views
       def included(type)
         @view.included_view_names.reduce({}) do |acc, view_name|
-          view = @blueprint.views.fetch(view_name)
+          view = @blueprint.reflections.fetch(view_name)
           acc.merge view.send(type)
         end
       end

--- a/lib/blueprinter/reflection.rb
+++ b/lib/blueprinter/reflection.rb
@@ -49,7 +49,7 @@ module Blueprinter
       #
       def fields
         @fields ||= @view.fields.each_with_object(included(:fields)) do |(_name, field), obj|
-          next unless field.options[:association]
+          next if field.options[:association]
 
           obj[field.method] = Field.new(field.method, field.name, field.options)
         end

--- a/lib/blueprinter/reflection.rb
+++ b/lib/blueprinter/reflection.rb
@@ -49,9 +49,9 @@ module Blueprinter
       #
       def fields
         @fields ||= @view.fields.each_with_object(included(:fields)) do |(_name, field), obj|
-          unless field.options[:association] # rubocop:todo Style/IfUnlessModifier
-            obj[field.method] = Field.new(field.method, field.name, field.options)
-          end
+          next unless field.options[:association]
+
+          obj[field.method] = Field.new(field.method, field.name, field.options)
         end
       end
 

--- a/spec/units/reflection_spec.rb
+++ b/spec/units/reflection_spec.rb
@@ -30,6 +30,18 @@ describe Blueprinter::Reflection do
         association :parts, blueprint: part_bp, view: :extended
       end
 
+      view :extended_plus do
+        include_view :extended
+        field :foo
+        association :foos, blueprint: part_bp
+      end
+
+      view :extended_plus_plus do
+        include_view :extended_plus
+        field :bar
+        association :bars, blueprint: part_bp
+      end
+
       view :legacy do
         association :parts, blueprint: part_bp, name: :pieces
       end
@@ -41,6 +53,8 @@ describe Blueprinter::Reflection do
       :identifier,
       :default,
       :extended,
+      :extended_plus,
+      :extended_plus_plus,
       :legacy,
     ]
   end
@@ -53,14 +67,23 @@ describe Blueprinter::Reflection do
     ]
   end
 
+  it 'should list fields from included views' do
+    expect(widget_blueprint.reflections.fetch(:extended_plus_plus).fields.keys).to eq [
+      :id,
+      :name,
+      :foo,
+      :bar,
+    ]
+  end
+
   it 'should list associations' do
     associations = widget_blueprint.reflections.fetch(:default).associations
     expect(associations.keys).to eq [:category]
   end
 
   it 'should list associations from included views' do
-    associations = widget_blueprint.reflections.fetch(:extended).associations
-    expect(associations.keys).to eq [:category, :parts]
+    associations = widget_blueprint.reflections.fetch(:extended_plus_plus).associations
+    expect(associations.keys).to eq [:category, :parts, :foos, :bars]
   end
 
   it 'should list associations using custom names' do

--- a/spec/units/reflection_spec.rb
+++ b/spec/units/reflection_spec.rb
@@ -40,7 +40,7 @@ describe Blueprinter::Reflection do
   }
 
   it 'should list views' do
-    expect(widget_blueprint.views.keys).to eq [
+    expect(widget_blueprint.reflections.keys).to eq [
       :identifier,
       :default,
       :extended,
@@ -49,7 +49,7 @@ describe Blueprinter::Reflection do
   end
 
   it 'should list fields' do
-    expect(part_blueprint.views.fetch(:extended).fields.keys).to eq [
+    expect(part_blueprint.reflections.fetch(:extended).fields.keys).to eq [
       :id,
       :name,
       :description,
@@ -57,23 +57,23 @@ describe Blueprinter::Reflection do
   end
 
   it 'should list associations' do
-    associations = widget_blueprint.views.fetch(:default).associations
+    associations = widget_blueprint.reflections.fetch(:default).associations
     expect(associations.keys).to eq [:category]
   end
 
   it 'should list associations from included views' do
-    associations = widget_blueprint.views.fetch(:extended).associations
+    associations = widget_blueprint.reflections.fetch(:extended).associations
     expect(associations.keys).to eq [:category, :parts]
   end
 
   it 'should list associations using custom names' do
-    associations = widget_blueprint.views.fetch(:legacy).associations
+    associations = widget_blueprint.reflections.fetch(:legacy).associations
     expect(associations.keys).to eq [:category, :parts]
     expect(associations[:parts].display_name).to eq :pieces
   end
 
   it 'should get a blueprint and view from an association' do
-    assoc = widget_blueprint.views[:extended].associations[:parts]
+    assoc = widget_blueprint.reflections[:extended].associations[:parts]
     expect(assoc.name).to eq :parts
     expect(assoc.display_name).to eq :parts
     expect(assoc.blueprint).to eq part_blueprint

--- a/spec/units/reflection_spec.rb
+++ b/spec/units/reflection_spec.rb
@@ -49,31 +49,31 @@ describe Blueprinter::Reflection do
   }
 
   it 'should list views' do
-    expect(widget_blueprint.reflections.keys).to eq [
+    expect(widget_blueprint.reflections.keys.sort).to eq [
       :identifier,
       :default,
       :extended,
       :extended_plus,
       :extended_plus_plus,
       :legacy,
-    ]
+    ].sort
   end
 
   it 'should list fields' do
-    expect(part_blueprint.reflections.fetch(:extended).fields.keys).to eq [
+    expect(part_blueprint.reflections.fetch(:extended).fields.keys.sort).to eq [
       :id,
       :name,
       :description,
-    ]
+    ].sort
   end
 
   it 'should list fields from included views' do
-    expect(widget_blueprint.reflections.fetch(:extended_plus_plus).fields.keys).to eq [
+    expect(widget_blueprint.reflections.fetch(:extended_plus_plus).fields.keys.sort).to eq [
       :id,
       :name,
       :foo,
       :bar,
-    ]
+    ].sort
   end
 
   it 'should list associations' do
@@ -83,7 +83,7 @@ describe Blueprinter::Reflection do
 
   it 'should list associations from included views' do
     associations = widget_blueprint.reflections.fetch(:extended_plus_plus).associations
-    expect(associations.keys).to eq [:category, :parts, :foos, :bars]
+    expect(associations.keys.sort).to eq [:category, :parts, :foos, :bars].sort
   end
 
   it 'should list associations using custom names' do

--- a/spec/units/reflection_spec.rb
+++ b/spec/units/reflection_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'json'
+
+describe Blueprinter::Reflection do
+  let(:category_blueprint) {
+    Class.new(Blueprinter::Base) do
+      fields :id, :name
+    end
+  }
+
+  let(:part_blueprint) {
+    Class.new(Blueprinter::Base) do
+      fields :id, :name
+
+      view :extended do
+        include_view :default
+        field :description
+      end
+    end
+  }
+
+  let(:widget_blueprint) {
+    cat_bp = category_blueprint
+    part_bp = part_blueprint
+    Class.new(Blueprinter::Base) do
+      fields :id, :name
+      association :category, blueprint: cat_bp
+
+      view :extended do
+        include_view :default
+        association :parts, blueprint: part_bp, view: :extended
+      end
+
+      view :legacy do
+        include_view :default
+        association :parts, blueprint: part_bp, name: :pieces
+      end
+    end
+  }
+
+  it 'should list views' do
+    expect(widget_blueprint.views.keys).to eq [
+      :identifier,
+      :default,
+      :extended,
+      :legacy,
+    ]
+  end
+
+  it 'should list fields' do
+    expect(part_blueprint.views.fetch(:extended).fields.keys).to eq [
+      :id,
+      :name,
+      :description,
+    ]
+  end
+
+  it 'should list associations' do
+    associations = widget_blueprint.views.fetch(:default).associations
+    expect(associations.keys).to eq [:category]
+  end
+
+  it 'should list associations from included views' do
+    associations = widget_blueprint.views.fetch(:extended).associations
+    expect(associations.keys).to eq [:category, :parts]
+  end
+
+  it 'should list associations using custom names' do
+    associations = widget_blueprint.views.fetch(:legacy).associations
+    expect(associations.keys).to eq [:category, :parts]
+    expect(associations[:parts].display_name).to eq :pieces
+  end
+
+  it 'should get a blueprint and view from an association' do
+    assoc = widget_blueprint.views[:extended].associations[:parts]
+    expect(assoc.name).to eq :parts
+    expect(assoc.display_name).to eq :parts
+    expect(assoc.blueprint).to eq part_blueprint
+    expect(assoc.view).to eq :extended
+  end
+end

--- a/spec/units/reflection_spec.rb
+++ b/spec/units/reflection_spec.rb
@@ -14,7 +14,6 @@ describe Blueprinter::Reflection do
       fields :id, :name
 
       view :extended do
-        include_view :default
         field :description
       end
     end
@@ -28,12 +27,10 @@ describe Blueprinter::Reflection do
       association :category, blueprint: cat_bp
 
       view :extended do
-        include_view :default
         association :parts, blueprint: part_bp, view: :extended
       end
 
       view :legacy do
-        include_view :default
         association :parts, blueprint: part_bp, name: :pieces
       end
     end


### PR DESCRIPTION
Initial attempt at a reflection API per #341. I've built a POC ActiveRecord automagic preloader against this and #358.

Blueprinter's native views and associations have been wrapped in simpler structs or classes, as the native ones made it pretty hard to get at stuff. Could also protect against internal changes in the future.

I exposed the internal `method` and `name` as `name` and `display_name` respectively, since Rubocop (and best practices) don't allow methods named "method".

```ruby
# Returns Hash of views keyed by name
views = WidgetBlueprint.reflections

# Returns Hash of non-association fields keyed by method name
fields = views[:default].fields
fields[:name].name
=> :name
fields[:name].display_name
=> :name

# Returns Hash of associations keyed by method name
assoc = views[:default].associations
assoc[:category].name
=> :category
assoc[:category].display_name
=> :category
assoc[:category].blueprint
=> CategoryBlueprint
assoc[:category].view
=> :default
```

TODO
- Update documentation if approach is approved
- Is there any missing info we feel is critical to expose for initial release?