### PR TITLE
Prevent re-adding same transformers to the view all the time

### DIFF
--- a/lib/blueprinter/view_collection.rb
+++ b/lib/blueprinter/view_collection.rb
@@ -36,7 +36,7 @@ module Blueprinter
 
     def transformers(view_name)
       included_transformers = gather_transformers_from_included_views(view_name).reverse
-      all_transformers = views[:default].view_transformers.concat(included_transformers).uniq
+      all_transformers = [*views[:default].view_transformers, *included_transformers].uniq
       all_transformers.empty? ? Blueprinter.configuration.default_transformers : all_transformers
     end
 
@@ -94,11 +94,12 @@ module Blueprinter
 
     def gather_transformers_from_included_views(view_name)
       current_view = views[view_name]
-      current_view.included_view_names.flat_map do |included_view_name|
+      already_included_transformers = current_view.included_view_names.flat_map do |included_view_name|
         next [] if view_name == included_view_name
 
         gather_transformers_from_included_views(included_view_name)
-      end.concat(current_view.view_transformers)
+      end
+      [*already_included_transformers, *current_view.view_transformers].uniq
     end
   end
 end

--- a/spec/benchmarks/ips_test.rb
+++ b/spec/benchmarks/ips_test.rb
@@ -9,8 +9,19 @@ class Blueprinter::IPSTest < Minitest::Test
 
   def setup
     @blueprinter = Class.new(Blueprinter::Base) do
+      transformer = Class.new(Blueprinter::Transformer) do
+        define_method :transform do |result_hash, _obj, _options|
+          {
+            foo: :bar,
+            **result_hash
+          }
+        end
+      end
+
       field :id
       field :name
+
+      transform transformer
     end
     @prepared_objects = 10.times.map {|i| OpenStruct.new(id: i, name: "obj #{i}")}
   end

--- a/spec/units/view_collection_spec.rb
+++ b/spec/units/view_collection_spec.rb
@@ -91,6 +91,12 @@ describe 'ViewCollection' do
       it 'should return both the view transformer and default transformers for the view' do
         expect(view_collection.transformers(:view)).to eq([default_transformer, transformer])
       end
+
+      it 'should not alter view transformers of the view on subsequent fetches' do
+        view_collection.transformers(:default)
+        expect { view_collection.transformers(:default) }
+          .not_to change(default_view.view_transformers, :count)
+      end
     end
 
     context 'include view transformer' do


### PR DESCRIPTION
While updating to the latest version, I've noticed that performance for rendering a blueprint with a transformer has worsened significantly. Digging around the code, I found that the issue is the usage of `concat` method which keeps adding and adding same transformers to the view on each call fetching defined transformers. This change is using simple array deconstructing to ensure immutability of the transformers array.

I've also added a case with a transformer to the basic benchmark spec because I think it's valuable to also have such a case there. Let me know if I need to make it more detailed or to also add it to other benchmark specs.

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
