### PR TITLE
Do not overwrite overridden fields and associations

### DIFF
--- a/lib/blueprinter/reflection.rb
+++ b/lib/blueprinter/reflection.rb
@@ -48,7 +48,7 @@ module Blueprinter
         @fields ||= @view_collection.fields_for(name).each_with_object({}) do |field, obj|
           next if field.options[:association]
 
-          obj[field.method] = Field.new(field.method, field.name, field.options)
+          obj[field.method] ||= Field.new(field.method, field.name, field.options)
         end
       end
 
@@ -63,7 +63,7 @@ module Blueprinter
 
           blueprint = field.options.fetch(:blueprint)
           view = field.options[:view] || :default
-          obj[field.method] = Association.new(field.method, field.name, blueprint, view, field.options)
+          obj[field.method] ||= Association.new(field.method, field.name, blueprint, view, field.options)
         end
       end
     end

--- a/spec/units/reflection_spec.rb
+++ b/spec/units/reflection_spec.rb
@@ -45,6 +45,11 @@ describe Blueprinter::Reflection do
       view :legacy do
         association :parts, blueprint: part_bp, name: :pieces
       end
+
+      view :aliased_names do
+        field :name, name: :aliased_name
+        association :category, blueprint: cat_bp, name: :aliased_category
+      end
     end
   }
 
@@ -56,6 +61,7 @@ describe Blueprinter::Reflection do
       :extended_plus,
       :extended_plus_plus,
       :legacy,
+      :aliased_names
     ].sort
   end
 
@@ -76,6 +82,17 @@ describe Blueprinter::Reflection do
     ].sort
   end
 
+  it 'should list overridden fields' do
+    fields = widget_blueprint.reflections.fetch(:aliased_names).fields
+    expect(fields.keys.sort).to eq [
+      :id,
+      :name,
+    ].sort
+    name_field = fields[:name]
+    expect(name_field.name).to eq :name
+    expect(name_field.display_name).to eq :aliased_name
+  end
+
   it 'should list associations' do
     associations = widget_blueprint.reflections.fetch(:default).associations
     expect(associations.keys).to eq [:category]
@@ -90,6 +107,16 @@ describe Blueprinter::Reflection do
     associations = widget_blueprint.reflections.fetch(:legacy).associations
     expect(associations.keys).to eq [:category, :parts]
     expect(associations[:parts].display_name).to eq :pieces
+  end
+
+  it 'should list overridden associations' do
+    associations = widget_blueprint.reflections.fetch(:aliased_names).associations
+    expect(associations.keys.sort).to eq [
+      :category
+    ].sort
+    category_association = associations[:category]
+    expect(category_association.name).to eq :category
+    expect(category_association.display_name).to eq :aliased_category
   end
 
   it 'should get a blueprint and view from an association' do


### PR DESCRIPTION
# Description
First off, thank y'all for adding this new reflection feature. It's super useful! I ran into an issue with fields and categories that exist in the default view but are overridden in other views. Reflections seem to get overwritten by their definitions in the default view instead of the other view. This PR changes the behavior to not overwrite overridden fields and associations with definitions in the default view.


Checklist:

- [X] I have updated the necessary documentation
- [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
- [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
