### PR TITLE
Fix Ruby 2.7 in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,11 +5,30 @@ on:
   pull_request:
     branches: [master, main]
 jobs:
+  test-old-ruby:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        ruby: ['2.7']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Installing dependencies
+        run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
+      - name: Run tests
+        run: bundle exec rake
+      - name: Benchmarks
+        run: bundle exec rake benchmarks
+
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2']
+        ruby: ['3.0', '3.1', '3.2']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,30 +5,15 @@ on:
   pull_request:
     branches: [master, main]
 jobs:
-  test-old-ruby:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        ruby: ['2.7']
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Ruby ${{ matrix.ruby }}
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-      - name: Installing dependencies
-        run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
-      - name: Run tests
-        run: bundle exec rake
-      - name: Benchmarks
-        run: bundle exec rake benchmarks
-
   test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        on: [ubuntu-latest]
         ruby: ['3.0', '3.1', '3.2']
+        include:
+          - os: ubuntu-20.04
+            ruby: '2.7'
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        on: [ubuntu-latest]
+        os: [ubuntu-latest]
         ruby: ['3.0', '3.1', '3.2']
         include:
           - os: ubuntu-20.04


### PR DESCRIPTION
Seems that GH has updated the `ubuntu-latest` image so that our deps for the 2.7 test runs no longer compile (as seen in recent PRs like #389). I pinned the 2.7 run to `ubuntu-20.04`, which seems to work.

There's a stuck "test (2.7)" job, but I'm hoping that's just some cached weirdness.