### PR TITLE
Use field.name when building reflective views and associations

### DIFF
--- a/lib/blueprinter/reflection.rb
+++ b/lib/blueprinter/reflection.rb
@@ -48,7 +48,7 @@ module Blueprinter
         @fields ||= @view_collection.fields_for(name).each_with_object({}) do |field, obj|
           next if field.options[:association]
 
-          obj[field.method] = Field.new(field.method, field.name, field.options)
+          obj[field.name] = Field.new(field.method, field.name, field.options)
         end
       end
 
@@ -63,7 +63,7 @@ module Blueprinter
 
           blueprint = field.options.fetch(:blueprint)
           view = field.options[:view] || :default
-          obj[field.method] = Association.new(field.method, field.name, blueprint, view, field.options)
+          obj[field.name] = Association.new(field.method, field.name, blueprint, view, field.options)
         end
       end
     end


### PR DESCRIPTION
# Description
This is a followup PR to #389, that fixes the problem at hand in a different (but more correct) way.

I ran into an issue with fields and categories that exist in the default view but are overridden in other views. Reflections seem to get overwritten by their definitions in the default view instead of the other view. This PR changes the behavior to key field and association reflections off of their `name` instead of their `method`, which the same way that Blueprinter uses when serializing data.

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
