### PR TITLE
Consistent field naming when aliasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,15 +115,15 @@ end
 <summary>Renaming</summary>
 
 
-You can rename the resulting JSON keys in both fields and associations by using the `name` option.
+You can rename the resulting JSON keys in both fields and associations by using the `source` option.
 
 ```ruby
 class UserBlueprint < Blueprinter::Base
   identifier :uuid
 
-  field :email, name: :login
+  field :login, source: :email
 
-  association :user_projects, name: :projects
+  association :projects, source: :user_projects
 end
 ```
 
@@ -148,7 +148,7 @@ You may define different outputs by utilizing views:
 ```ruby
 class UserBlueprint < Blueprinter::Base
   identifier :uuid
-  field :email, name: :login
+  field :login, source: :email
 
   view :normal do
     fields :first_name, :last_name
@@ -217,7 +217,7 @@ You can also optionally pass in a root key to wrap your resulting json in:
 ```ruby
 class UserBlueprint < Blueprinter::Base
   identifier :uuid
-  field :email, name: :login
+  field :login, source: :email
 
   view :normal do
     fields :first_name, :last_name
@@ -255,7 +255,7 @@ You can additionally add meta-data to the json as well:
 ```ruby
 class UserBlueprint < Blueprinter::Base
   identifier :uuid
-  field :email, name: :login
+  field :login, source: :email
 
   view :normal do
     fields :first_name, :last_name
@@ -305,7 +305,7 @@ You can specifically choose to exclude certain fields for specific views
 ```ruby
 class UserBlueprint < Blueprinter::Base
   identifier :uuid
-  field :email, name: :login
+  field :login, source: :email
 
   view :normal do
     fields :first_name, :last_name
@@ -341,7 +341,7 @@ Use `excludes` to exclude multiple fields at once inline.
 ```ruby
 class UserBlueprint < Blueprinter::Base
   identifier :uuid
-  field :email, name: :login
+  field :login, source: :email
 
   view :normal do
     fields :age, :first_name, :last_name,
@@ -371,7 +371,7 @@ end
 
 class UserBlueprint < Blueprinter::Base
   identifier :uuid
-  field :email, name: :login
+  field :login, source: :email
 
   view :normal do
     fields :first_name, :last_name

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -56,10 +56,10 @@ module Blueprinter
     #   end
     #
     # @return [Field] A Field object
-    def self.identifier(name, source: name, extractor: Blueprinter.configuration.extractor_default.new, &block)
+    def self.identifier(name, source: name, extractor: Blueprinter.configuration.extractor_default.new, **options, &block)
       view_collection[:identifier] << Field.new(
         source,
-        name,
+        options.fetch(:name) { name }, # @deprecated option
         extractor,
         self,
         block: block
@@ -123,7 +123,7 @@ module Blueprinter
     def self.field(name, options = {}, &block)
       current_view << Field.new(
         options.fetch(:source) { name },
-        name,
+        options.fetch(:name) { name }, # @deprecated option
         options.fetch(:extractor) { Blueprinter.configuration.extractor_default.new },
         self,
         options.merge(block: block)

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -43,7 +43,7 @@ shared_examples 'Base::render' do
     let(:result) { '{"first_name":"Meg","identifier":' + obj_id + '}' }
     let(:blueprint) do
       Class.new(Blueprinter::Base) do
-        field :id, name: :identifier
+        field :identifier, source: :id
         field :first_name
       end
     end
@@ -379,7 +379,7 @@ shared_examples 'Base::render' do
 
         view :normal do
           fields :last_name, :position
-          field :company, name: :employer
+          field :employer, source: :company
           field :points do 1 end
         end
         view :extended do

--- a/spec/units/reflection_spec.rb
+++ b/spec/units/reflection_spec.rb
@@ -43,17 +43,17 @@ describe Blueprinter::Reflection do
       end
 
       view :legacy do
-        association :parts, blueprint: part_bp, name: :pieces
+        association :pieces, blueprint: part_bp, source: :parts
       end
 
       view :aliased_names do
-        field :name, name: :aliased_name
-        association :category, blueprint: cat_bp, name: :aliased_category
+        field :aliased_name, source: :name
+        association :aliased_category, blueprint: cat_bp, source: :category
       end
 
       view :overridden_fields do
-        field :override_field, name: :name
-        association :overridden_category, name: :category, blueprint: cat_bp
+        field :name, source: :override_field
+        association :category, source: :overridden_category, blueprint: cat_bp
       end
     end
   }


### PR DESCRIPTION
This fixes #281 by adding a new `source:` option to fields, identifiers and associations, as a replacement for the `name:` option.

The beauty of this approach is that the structure of the resulting JSON document can more easily recognized even when "squinting" and only looking at the first parameter of each field or association:

```ruby
class MyBlueprint < Blueprinter::Base
  identifier :uuid, source: :id

  field :title, source: :title_string
  association :owner, blueprint: UserBlueprint, source: :user
end
```

I tweaked all existing tests and made them pass. To get this out of draft state:

* [x] Agree on naming
* [ ] Add tests for deprecated `name:` options
* [ ] Add deprecation warnings when using deprecated `name:` options

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [x] My build is green