### PR TITLE
chore: add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,66 @@
+name: 🐞 Bug
+description: File a bug/issue
+title: "[bug] <title>"
+labels: [bug, needs-triage]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: checkboxes
+  attributes:
+    label: Is this a regression?
+    description: Did this behavior work before?
+    options:
+    - label: Yes, this used to work before
+      required: false
+- type: textarea
+  attributes:
+    label: Current Behavior
+    description: A concise description of what you're experiencing.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A concise description of what you expected to happen.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: Steps to reproduce the behavior.
+    placeholder: |
+      1.
+      2.
+      3.
+      4.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Environment
+    description: |
+      examples:
+        - **OS**: OSX 13.3.1
+        - **Browser Name and Version**: Chrome Version 112.0.5615.49 (Official Build) (arm64)
+        - **Ruby Version**: 3.0.0
+    value: |
+        - OS:
+        - Browser Name and version:
+        - Ruby Version:
+    render: markdown
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Anything that will give us more context about the issue you are encountering!
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,18 @@
+name: 📚 Documentation or README.md issue report
+description: File a bug/issue for docs or README.md
+title: "[bug] <title>"
+labels: [docs, needs-triage]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Docs/README.md Part to update
+    description: A concise description of what you thing should be updated
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -18,7 +18,7 @@ body:
     required: true
 - type: textarea
   attributes:
-    label: Describe the solution you'd lik
+    label: Describe the feature you'd like to see implemented
     description: A clear and concise description of what you want to happen
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,36 @@
+name: 🚀🆕 Feature Request
+description: Suggest an idea or possible new feature for this project
+title: "[Feature Request] <title>"
+labels: [feature, needs-triage]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Is your feature request related to a problem? Please describe
+    description: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Describe the solution you'd lik
+    description: A clear and concise description of what you want to happen
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Describe alternatives you've considered
+    description: A clear and concise description of any alternative solutions or features you've considered
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Additional context
+    description: Add any other context or additional information about the problem here
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/question-support.yml
+++ b/.github/ISSUE_TEMPLATE/question-support.yml
@@ -1,0 +1,18 @@
+name: ❓ Question or Support Request
+description: Questions and requests for support
+title: "[Question/Support] <title>"
+labels: [question, support, needs-triage]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Describe your question or ask for support
+    description: A concise description of what you would like support with
+  validations:
+    required: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -63,7 +63,7 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
 <opensource@procore.com>.
 All complaints will be reviewed and investigated promptly and fairly by
-the [Procore Open Source Program Office (OSPO)](docs/contact.md)
+the Procore Open Source Program Office (OSPO)
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.

--- a/blueprinter.gemspec
+++ b/blueprinter.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.name        = 'blueprinter'
   s.version     = Blueprinter::VERSION
   s.authors     = ['Procore Technologies, Inc.']
-  s.email       = ['blueprinter@googlegroups.com']
+  s.email       = ['opensource@procore.com']
   s.homepage    = 'https://github.com/procore-oss/blueprinter'
   s.summary     = 'Simple Fast Declarative Serialization Library'
   s.description = 'Blueprinter is a JSON Object Presenter for Ruby that takes business objects ' \


### PR DESCRIPTION
You can find examples [here](https://github.com/procore-oss/oss-template/issues/new/choose)

- [Bug Issue](https://github.com/procore-oss/oss-template/issues/new?assignees=&labels=bug%2Cneeds-triage&projects=&template=bug.yml&title=%5Bbug%5D+%3Ctitle%3E)
- [Documentation Issue](https://github.com/procore-oss/oss-template/issues/new?assignees=&labels=docs%2Cneeds-triage&projects=&template=docs.yml&title=%5Bbug%5D+%3Ctitle%3E) 
- [Feature Issue](https://github.com/procore-oss/oss-template/issues/new?assignees=&labels=feature%2Cneeds-triage&projects=&template=feature-request.yml&title=%5BFeature+Request%5D+%3Ctitle%3E)
- [Question Issue](https://github.com/procore-oss/oss-template/issues/new?assignees=&labels=question%2Csupport%2Cneeds-triage&projects=&template=question-support.yml&title=%5BQuestion%2FSupport%5D+%3Ctitle%3E)

- [x] remove broken link in CODE_OF_CONDUCT.md
- [x] change gemspec email to opensource@procore.com

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
