### PR TITLE
Conditional views

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,3 +26,7 @@ gem 'rubocop', '~> 1.44'
 gem 'rubocop-rake'
 gem 'sqlite3', '~> 1.5'
 gem 'yard', '>= 0.9.34'
+
+group :development do
+  gem 'debug'
+end

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -412,6 +412,7 @@ module Blueprinter
     # It accepts a view name and a block. The block should specify the fields.
     #
     # @param view_name [Symbol] the view name
+    # @option if [Proc] A condition that applies to all fields in the view
     # @yieldreturn [#fields,#field,#include_view,#exclude] Use this block to
     #   specify fields, include fields from other views, or exclude fields.
     #
@@ -423,10 +424,13 @@ module Blueprinter
     #   end
     #
     # @return [View] a Blueprinter::View object
-    def self.view(view_name)
-      @current_view = view_collection[view_name]
+    def self.view(view_name, **options)
+      @current_view = view_collection.define(view_name, options)
       view_collection[:default].track_definition_order(view_name)
-      yield
+
+      yield if block_given?
+
+      @current_view.finalize
       @current_view = view_collection[:default]
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'blueprinter'
 require 'json'
+require 'debug'
 
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |file| require file }
 

--- a/spec/units/field_spec.rb
+++ b/spec/units/field_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+describe '::Field' do
+  let(:name) { :some_field_name }
+  let(:method) { :some_method }
+
+  let(:extractor) { double }
+  let(:blueprint) { double }
+  let(:options) { {} }
+
+  subject(:field) { Blueprinter::Field.new(method, name, extractor, blueprint, options) }
+
+  describe '#skip' do
+    let(:field_name) { :runtime_field_name }
+    let(:local_options) { {} }
+
+    let(:if_allowed) { {if: ->(fn, obj, opts) { obj.allowed }} }
+    let(:unless_prevented) { {unless: ->(fn, obj, opts) { obj.prevented }} }
+
+    context 'with neither unless nor if' do
+      let(:object) { double }
+
+      it { is_expected.not_to be_skip(field_name, object, local_options) }
+
+      context "with another condition" do
+        let(:extra_condition) do
+          extra = extra_state
+          ->(_fn, _obj, _opts) { extra }
+        end
+
+        before do
+          field.add_if(extra_condition)
+        end
+
+        context "when it is true" do
+          let(:extra_state) { true }
+
+          it { is_expected.not_to be_skip(field_name, object, local_options) }
+        end
+
+        context "when it is false" do
+          let(:extra_state) { false }
+
+          it { is_expected.to be_skip(field_name, object, local_options) }
+        end
+      end
+    end
+
+    context 'with unless only' do
+      let(:object) { double(prevented: prevented) }
+      let(:options) { unless_prevented }
+
+      context "when prevented" do
+        let(:prevented) { true }
+
+        it { is_expected.to be_skip(field_name, object, local_options) }
+      end
+
+      context "when not prevented" do
+        let(:prevented) { false }
+
+        it { is_expected.not_to be_skip(field_name, object, local_options) }
+      end
+
+    end
+
+    context 'with if only' do
+      let(:object) { double(allowed: allowed) }
+      let(:options) { if_allowed }
+
+      context "when allowed" do
+        let(:allowed) { true }
+
+        it { is_expected.not_to be_skip(field_name, object, local_options) }
+      end
+
+      context "when not allowed" do
+        let(:allowed) { false }
+
+        it { is_expected.to be_skip(field_name, object, local_options) }
+      end
+
+      context "with another condition" do
+        let(:extra_condition) do
+          extra = extra_state
+          ->(_fn, _obj, _opts) { extra }
+        end
+
+        before do
+          field.add_if(extra_condition)
+        end
+
+        context "when it is true, and allowed is true" do
+          let(:extra_state) { true }
+          let(:allowed) { true }
+
+          it { is_expected.not_to be_skip(field_name, object, local_options) }
+        end
+
+        context "when it is true, and allowed is false" do
+          let(:extra_state) { true }
+          let(:allowed) { false }
+
+          it { is_expected.to be_skip(field_name, object, local_options) }
+        end
+
+        context "when it is false" do
+          let(:extra_state) { false }
+          let(:allowed) { :irrelevant }
+
+          it { is_expected.to be_skip(field_name, object, local_options) }
+        end
+      end
+    end
+
+    context 'with unless and if' do
+      let(:object) { double(prevented: prevented, allowed: allowed) }
+      let(:options) { if_allowed.merge(unless_prevented) }
+
+      context "when allowed, and not prevented" do
+        let(:allowed) { true }
+        let(:prevented) { false }
+
+        it { is_expected.not_to be_skip(field_name, object, local_options) }
+      end
+
+      context "when allowed, and prevented" do
+        let(:allowed) { true }
+        let(:prevented) { true }
+
+        it { is_expected.to be_skip(field_name, object, local_options) }
+      end
+
+      context "when not allowed, and prevented" do
+        let(:allowed) { false }
+        let(:prevented) { true }
+
+        it { is_expected.to be_skip(field_name, object, local_options) }
+      end
+
+      context "when not allowed, and not prevented" do
+        let(:allowed) { false }
+        let(:prevented) { true }
+
+        it { is_expected.to be_skip(field_name, object, local_options) }
+      end
+    end
+  end
+end

--- a/spec/units/view_collection_spec.rb
+++ b/spec/units/view_collection_spec.rb
@@ -23,6 +23,20 @@ describe 'ViewCollection' do
     end
   end
 
+  describe '#define' do
+    it 'creates a view with the given options' do
+      new_view = view_collection.define(:new_view, {if: :some_method_name})
+
+      expect(view_collection[:new_view]).to eq(new_view)
+    end
+
+    it 'errors if this view has already defined a view of the same name' do
+      view_collection.define(:new_view, {})
+
+      expect { view_collection.define(:new_view, {}) }.to raise_error(KeyError)
+    end
+  end
+
   describe '#[]' do
     it 'should return the view if it exists' do
       expect(view_collection.views[:default]).to eq(default_view)
@@ -53,7 +67,7 @@ describe 'ViewCollection' do
 
     it 'should inherit the fields from the parent view collection' do
       view_collection.inherit(parent_view_collection)
-      expect(view.fields).to include(parent_view_collection[:view].fields)
+      expect(view.fields.keys).to include(*parent_view_collection[:view].fields.keys)
     end
   end
 

--- a/spec/units/view_spec.rb
+++ b/spec/units/view_spec.rb
@@ -14,6 +14,31 @@ describe '::View' do
     end
   end
 
+  describe "#finalize" do
+    let(:fields) { {a: double, b: double, c: double} }
+    let(:view) { Blueprinter::View.new('With IF', fields: fields, local_options: { if: if_condition }) }
+
+    context "without an if condition" do
+      let(:if_condition) { nil }
+
+      it "does nothing" do
+        view.finalize
+      end
+    end
+
+    context "when there is an if condition" do
+      let(:if_condition) { :some_condition }
+
+      it "adds the condition to each field" do
+        expect(fields[:a]).to receive(:add_if).with(if_condition)
+        expect(fields[:b]).to receive(:add_if).with(if_condition)
+        expect(fields[:c]).to receive(:add_if).with(if_condition)
+
+        view.finalize
+      end
+    end
+  end
+
   describe '#include_views(:view_name)' do
     it 'should return [:view_name]' do
       expect(view.include_views([:normal, :special])).to eq([:normal, :special])


### PR DESCRIPTION
Prior to this change, applying conditions to a view required annotating
all fields individually.

This change allows views to be defined as `view :name, if: condition`,
using the same `->(field_name, object, options) { ... }` callbacks as
used on fields. These callbacks are propagated to the fields, and are in
addition to (not in replacement of) any checks defined on the fields.

Tests are added to cover the logic of `unless` and `if`, and
`Field#skip?` is altered to allow a field to have both `unless` and `if`
defined.

Defining a view-level condition on an child blueprint does not affect
the parent view of the same name - this behavior may be unexpected, and
it is advised not to add conditions to inherited views, since this may
represent a security flaw.

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [ ] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
