### PR TITLE
Remove Custom Array-like Class Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,24 +91,6 @@ This will result in JSON that looks something like this:
   }
 ]
 ```
-
-
-You can also configure other classes to be treated like collections. For example, if you are using Mongoid, you can configure it to treat `Mongoid::Criteria` objects as collections:
-
-```ruby
-Blueprinter.configure do |config|
-  config.custom_array_like_classes = [Mongoid::Criteria]
-end
-```
-
-Or if you wanted it to treat the `Set` class as a collection:
-
-```ruby
-Blueprinter.configure do |config|
-  config.custom_array_like_classes = [Set]
-end
-```
-
 </details>
 
 <details>

--- a/lib/blueprinter/configuration.rb
+++ b/lib/blueprinter/configuration.rb
@@ -5,7 +5,7 @@ require_relative 'extensions'
 module Blueprinter
   class Configuration
     attr_accessor :association_default, :datetime_format, :deprecations, :field_default, :generator, :if, :method,
-                  :sort_fields_by, :unless, :extractor_default, :default_transformers, :custom_array_like_classes
+                  :sort_fields_by, :unless, :extractor_default, :default_transformers
 
     VALID_CALLABLES = %i[if unless].freeze
 
@@ -21,7 +21,6 @@ module Blueprinter
       @unless = nil
       @extractor_default = AutoExtractor
       @default_transformers = []
-      @custom_array_like_classes = []
     end
 
     def extensions
@@ -30,14 +29,6 @@ module Blueprinter
 
     def extensions=(list)
       @extensions = Extensions.new(list)
-    end
-
-    def array_like_classes
-      @array_like_classes ||= [
-        Array,
-        defined?(ActiveRecord::Relation) && ActiveRecord::Relation,
-        *custom_array_like_classes
-      ].compact
     end
 
     def jsonify(blob)

--- a/lib/blueprinter/configuration.rb
+++ b/lib/blueprinter/configuration.rb
@@ -4,8 +4,19 @@ require_relative 'extensions'
 
 module Blueprinter
   class Configuration
-    attr_accessor :association_default, :datetime_format, :deprecations, :field_default, :generator, :if, :method,
-                  :sort_fields_by, :unless, :extractor_default, :default_transformers
+    attr_accessor(
+      :association_default,
+      :datetime_format,
+      :default_transformers,
+      :deprecations,
+      :extractor_default,
+      :field_default,
+      :generator,
+      :if,
+      :method,
+      :sort_fields_by,
+      :unless
+    )
 
     VALID_CALLABLES = %i[if unless].freeze
 

--- a/lib/blueprinter/helpers/type_helpers.rb
+++ b/lib/blueprinter/helpers/type_helpers.rb
@@ -5,9 +5,7 @@ module Blueprinter
     private
 
     def array_like?(object)
-      Blueprinter.configuration.array_like_classes.any? do |klass|
-        object.is_a?(klass)
-      end
+      object.is_a?(Enumerable) && !object.is_a?(Hash)
     end
   end
 end

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -58,30 +58,6 @@ describe '::Base' do
       end
     end
 
-    context 'Given passed object is array-like' do
-      let(:blueprint) { blueprint_with_block }
-      let(:additional_object) { OpenStruct.new(obj_hash.merge(id: 2)) }
-      let(:obj) { Set.new([object_with_attributes, additional_object]) }
-
-      context 'and is an instance of a configured array-like class' do
-        before do
-          reset_blueprinter_config!
-          Blueprinter.configure { |config| config.custom_array_like_classes = [Set] }
-        end
-        after { reset_blueprinter_config! }
-
-        it 'should return the expected array of hashes' do
-          should eq('[{"id":1,"position_and_company":"Manager at Procore"},{"id":2,"position_and_company":"Manager at Procore"}]')
-        end
-      end
-
-      context 'and is not an instance of a configured array-like class' do
-        it 'should raise an error' do
-          expect { blueprint.render(obj) }.to raise_error(NoMethodError)
-        end
-      end
-    end
-
     context 'Inside Rails project' do
       include FactoryBot::Syntax::Methods
       let(:obj) { create(:user) }
@@ -406,36 +382,6 @@ describe '::Base' do
             end
           end
         end
-      end
-
-      context 'Given passed object is an instance of a configured array-like class' do
-        let(:blueprint) do
-          Class.new(Blueprinter::Base) do
-            identifier :id
-            fields :make
-          end
-        end
-        let(:vehicle1) { build(:vehicle, id: 1) }
-        let(:vehicle2) { build(:vehicle, id: 2, make: 'Mediocre Car') }
-        let(:vehicle3) { build(:vehicle, id: 3, make: 'Terrible Car') }
-        let(:vehicles) { [vehicle1, vehicle2, vehicle3] }
-        let(:obj) { Set.new(vehicles) }
-        let(:result) do
-          vehicles_json = vehicles.map do |vehicle|
-            "{\"id\":#{vehicle.id},\"make\":\"#{vehicle.make}\"}"
-          end.join(',')
-          "[#{vehicles_json}]"
-        end
-
-        before do
-          reset_blueprinter_config!
-          Blueprinter.configure do |config|
-            config.custom_array_like_classes = [Set]
-          end
-        end
-        after { reset_blueprinter_config! }
-
-        it('returns the expected result') { should eq(result) }
       end
     end
   end


### PR DESCRIPTION
## Changelog
- Removes custom array-like configuration in favor of depending on an interface (`Enumerable` in this case). `Hash` is an exception here due to existing implementation details. 

## Discussion
This was [previously discussed](https://github.com/blueprinter-ruby/blueprinter/pull/2) as an option, but was decided against  due to potentially be _too_ open. 

Checklist:

* [X ] I have updated the necessary documentation
* [X ] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [ ] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
