### PR TITLE
Explicitly Require JSON Library

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -3,7 +3,6 @@
 
 require 'bundler/setup'
 require 'blueprinter'
-require 'json'
 
 require 'irb'
 IRB.start(__FILE__)

--- a/lib/blueprinter/configuration.rb
+++ b/lib/blueprinter/configuration.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'json'
 require_relative 'extensions'
 
 module Blueprinter

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'blueprinter'
-require 'json'
 
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |file| require file }
 

--- a/spec/units/extensions_spec.rb
+++ b/spec/units/extensions_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
 require 'ostruct'
 
 describe Blueprinter::Extensions do

--- a/spec/units/reflection_spec.rb
+++ b/spec/units/reflection_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-
 describe Blueprinter::Reflection do
   let(:category_blueprint) {
     Class.new(Blueprinter::Base) do


### PR DESCRIPTION
Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->

## Background

Fixes #443 

There's been a longstanding _implicit_ dependency on the standard `json` library, as `Blueprinter::Configuration` requires it to be available in the case where a separate JSON library isn't specified on configuration. This hasn't caused many issues in the past, as most use cases for `Blueprinter` are in environments where `json` is loaded (e.g. a Rails application). 

However, this is a brittle dependency, and if we're explicitly defining a default, we should make sure it's available in the confines of the class that needs it. 

## Changelog
- Explicitly `require 'json'` within `Blueprinter::Configuration`.
- Remove `require 'json'` from specs. 