### PR TITLE
Use autoload instead of require/require_relative

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ YARD::Rake::YardocTask.new do |t|
 end
 
 Rake::TestTask.new(:benchmarks) do |t|
-  t.libs << 'spec'
+  t.libs << 'spec' << 'lib'
   t.pattern = 'spec/benchmarks/**/*_test.rb'
   t.verbose = false
 end

--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ YARD::Rake::YardocTask.new do |t|
 end
 
 Rake::TestTask.new(:benchmarks) do |t|
-  t.libs << 'spec' << 'lib'
+  t.libs.append('lib', 'spec')
   t.pattern = 'spec/benchmarks/**/*_test.rb'
   t.verbose = false
 end

--- a/lib/blueprinter.rb
+++ b/lib/blueprinter.rb
@@ -1,7 +1,37 @@
 # frozen_string_literal: true
 
-require_relative 'blueprinter/base'
-require_relative 'blueprinter/extension'
-
 module Blueprinter
+  # Core
+  autoload :Association, 'blueprinter/association'
+  autoload :Base, 'blueprinter/base'
+  autoload :Configuration, 'blueprinter/configuration'
+  autoload :Deprecation, 'blueprinter/deprecation'
+  autoload :Extension, 'blueprinter/extension'
+  autoload :Extensions, 'blueprinter/extensions'
+  autoload :Field, 'blueprinter/field'
+  autoload :Reflection, 'blueprinter/reflection'
+  autoload :View, 'blueprinter/view'
+  autoload :ViewCollection, 'blueprinter/view_collection'
+
+  # Extractors & Transfomers
+  autoload :AssociationExtractor, 'blueprinter/extractors/association_extractor'
+  autoload :AutoExtractor, 'blueprinter/extractors/auto_extractor'
+  autoload :BlockExtractor, 'blueprinter/extractors/block_extractor'
+  autoload :Extractor, 'blueprinter/extractor'
+  autoload :HashExtractor, 'blueprinter/extractors/hash_extractor'
+  autoload :PublicSendExtractor, 'blueprinter/extractors/public_send_extractor'
+  autoload :Transformer, 'blueprinter/transformer'
+
+  # Helpers & Types
+  autoload :BaseHelpers, 'blueprinter/helpers/base_helpers'
+  autoload :DateTimeFormatter, 'blueprinter/formatters/date_time_formatter'
+  autoload :EmptyTypes, 'blueprinter/empty_types'
+  autoload :TypeHelpers, 'blueprinter/helpers/type_helpers'
+
+  # Errors & Validation
+  autoload :BlueprinterError, 'blueprinter/blueprinter_error'
+  autoload :BlueprintValidator, 'blueprinter/blueprint_validator'
+  autoload :Errors, 'blueprinter/errors'
+
+  extend Configuration::Configurable
 end

--- a/lib/blueprinter.rb
+++ b/lib/blueprinter.rb
@@ -1,37 +1,26 @@
 # frozen_string_literal: true
 
 module Blueprinter
-  # Core
-  autoload :Association, 'blueprinter/association'
   autoload :Base, 'blueprinter/base'
+  autoload :BlueprinterError, 'blueprinter/blueprinter_error'
   autoload :Configuration, 'blueprinter/configuration'
-  autoload :Deprecation, 'blueprinter/deprecation'
+  autoload :Errors, 'blueprinter/errors'
   autoload :Extension, 'blueprinter/extension'
-  autoload :Extensions, 'blueprinter/extensions'
-  autoload :Field, 'blueprinter/field'
-  autoload :Reflection, 'blueprinter/reflection'
-  autoload :View, 'blueprinter/view'
-  autoload :ViewCollection, 'blueprinter/view_collection'
-
-  # Extractors & Transfomers
-  autoload :AssociationExtractor, 'blueprinter/extractors/association_extractor'
-  autoload :AutoExtractor, 'blueprinter/extractors/auto_extractor'
-  autoload :BlockExtractor, 'blueprinter/extractors/block_extractor'
-  autoload :Extractor, 'blueprinter/extractor'
-  autoload :HashExtractor, 'blueprinter/extractors/hash_extractor'
-  autoload :PublicSendExtractor, 'blueprinter/extractors/public_send_extractor'
   autoload :Transformer, 'blueprinter/transformer'
 
-  # Helpers & Types
-  autoload :BaseHelpers, 'blueprinter/helpers/base_helpers'
-  autoload :DateTimeFormatter, 'blueprinter/formatters/date_time_formatter'
-  autoload :EmptyTypes, 'blueprinter/empty_types'
-  autoload :TypeHelpers, 'blueprinter/helpers/type_helpers'
+  class << self
+    # @return [Configuration]
+    def configuration
+      @configuration ||= Configuration.new
+    end
 
-  # Errors & Validation
-  autoload :BlueprinterError, 'blueprinter/blueprinter_error'
-  autoload :BlueprintValidator, 'blueprinter/blueprint_validator'
-  autoload :Errors, 'blueprinter/errors'
+    def configure
+      yield(configuration) if block_given?
+    end
 
-  extend Configuration::Configurable
+    # Resets global configuration.
+    def reset_configuration!
+      @configuration = nil
+    end
+  end
 end

--- a/lib/blueprinter/association.rb
+++ b/lib/blueprinter/association.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'blueprinter/field'
+require 'blueprinter/blueprint_validator'
+require 'blueprinter/extractors/association_extractor'
+
 module Blueprinter
   # @api private
   class Association < Field

--- a/lib/blueprinter/association.rb
+++ b/lib/blueprinter/association.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'field'
-require_relative 'blueprint_validator'
-
 module Blueprinter
   # @api private
   class Association < Field

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+require 'blueprinter/association'
+require 'blueprinter/extractors/association_extractor'
+require 'blueprinter/field'
+require 'blueprinter/helpers/base_helpers'
+require 'blueprinter/reflection'
+
 module Blueprinter
   class Base
     include BaseHelpers

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -1,26 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'association'
-require_relative 'blueprint_validator'
-require_relative 'blueprinter_error'
-require_relative 'configuration'
-require_relative 'deprecation'
-require_relative 'empty_types'
-require_relative 'extractor'
-require_relative 'extractors/association_extractor'
-require_relative 'extractors/auto_extractor'
-require_relative 'extractors/block_extractor'
-require_relative 'extractors/hash_extractor'
-require_relative 'extractors/public_send_extractor'
-require_relative 'field'
-require_relative 'formatters/date_time_formatter'
-require_relative 'helpers/base_helpers'
-require_relative 'helpers/type_helpers'
-require_relative 'reflection'
-require_relative 'transformer'
-require_relative 'view_collection'
-require_relative 'view'
-
 module Blueprinter
   class Base
     include BaseHelpers

--- a/lib/blueprinter/blueprint_validator.rb
+++ b/lib/blueprinter/blueprint_validator.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'errors/invalid_blueprint'
-
 module Blueprinter
   # @api private
   class BlueprintValidator

--- a/lib/blueprinter/configuration.rb
+++ b/lib/blueprinter/configuration.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'blueprinter/extensions'
+require 'blueprinter/extractors/auto_extractor'
 
 module Blueprinter
   class Configuration
@@ -46,16 +48,6 @@ module Blueprinter
 
     def valid_callable?(callable_name)
       VALID_CALLABLES.include?(callable_name)
-    end
-
-    module Configurable
-      def configuration
-        @configuration ||= Configuration.new
-      end
-
-      def configure
-        yield configuration if block_given?
-      end
     end
   end
 end

--- a/lib/blueprinter/configuration.rb
+++ b/lib/blueprinter/configuration.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'json'
-require_relative 'extensions'
 
 module Blueprinter
   class Configuration
@@ -48,13 +47,15 @@ module Blueprinter
     def valid_callable?(callable_name)
       VALID_CALLABLES.include?(callable_name)
     end
-  end
 
-  def self.configuration
-    @configuration ||= Configuration.new
-  end
+    module Configurable
+      def configuration
+        @configuration ||= Configuration.new
+      end
 
-  def self.configure
-    yield configuration if block_given?
+      def configure
+        yield configuration if block_given?
+      end
+    end
   end
 end

--- a/lib/blueprinter/empty_types.rb
+++ b/lib/blueprinter/empty_types.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'helpers/type_helpers'
-
 module Blueprinter
   EMPTY_COLLECTION = 'empty_collection'
   EMPTY_HASH = 'empty_hash'

--- a/lib/blueprinter/empty_types.rb
+++ b/lib/blueprinter/empty_types.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'blueprinter/helpers/type_helpers'
+
 module Blueprinter
   EMPTY_COLLECTION = 'empty_collection'
   EMPTY_HASH = 'empty_hash'

--- a/lib/blueprinter/errors.rb
+++ b/lib/blueprinter/errors.rb
@@ -2,6 +2,6 @@
 
 module Blueprinter
   module Errors
-    class InvalidBlueprint < Blueprinter::BlueprinterError; end
+    autoload :InvalidBlueprint, 'blueprinter/errors/invalid_blueprint'
   end
 end

--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'blueprinter/extractor'
+require 'blueprinter/empty_types'
+
 module Blueprinter
   # @api private
   class AssociationExtractor < Extractor

--- a/lib/blueprinter/extractors/auto_extractor.rb
+++ b/lib/blueprinter/extractors/auto_extractor.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+require 'blueprinter/extractor'
+require 'blueprinter/empty_types'
+require 'blueprinter/extractors/block_extractor'
+require 'blueprinter/extractors/hash_extractor'
+require 'blueprinter/extractors/public_send_extractor'
+require 'blueprinter/formatters/date_time_formatter'
+
 module Blueprinter
   # @api private
   class AutoExtractor < Extractor

--- a/lib/blueprinter/extractors/block_extractor.rb
+++ b/lib/blueprinter/extractors/block_extractor.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'blueprinter/extractor'
+
 module Blueprinter
   # @api private
   class BlockExtractor < Extractor

--- a/lib/blueprinter/extractors/hash_extractor.rb
+++ b/lib/blueprinter/extractors/hash_extractor.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'blueprinter/extractor'
+
 module Blueprinter
   # @api private
   class HashExtractor < Extractor

--- a/lib/blueprinter/extractors/public_send_extractor.rb
+++ b/lib/blueprinter/extractors/public_send_extractor.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'blueprinter/extractor'
+
 module Blueprinter
   # @api private
   class PublicSendExtractor < Extractor

--- a/lib/blueprinter/helpers/base_helpers.rb
+++ b/lib/blueprinter/helpers/base_helpers.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'blueprinter/helpers/type_helpers'
+require 'blueprinter/view_collection'
+
 module Blueprinter
   module BaseHelpers
     def self.included(base)

--- a/lib/blueprinter/view_collection.rb
+++ b/lib/blueprinter/view_collection.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'blueprinter/view'
+
 module Blueprinter
   # @api private
   class ViewCollection

--- a/spec/benchmarks/active_record_big_o_test.rb
+++ b/spec/benchmarks/active_record_big_o_test.rb
@@ -2,7 +2,7 @@
 
 require 'activerecord_helper'
 require 'benchmark_helper'
-require 'blueprinter/base'
+require 'blueprinter'
 
 class Blueprinter::ActiveRecordBigOTest < Minitest::Benchmark
   include FactoryBot::Syntax::Methods

--- a/spec/benchmarks/active_record_ips_test.rb
+++ b/spec/benchmarks/active_record_ips_test.rb
@@ -2,7 +2,7 @@
 
 require 'activerecord_helper'
 require 'benchmark_helper'
-require 'blueprinter/base'
+require 'blueprinter'
 
 class Blueprinter::ActiveRecordIPSTest < Minitest::Test
   include FactoryBot::Syntax::Methods

--- a/spec/benchmarks/big_o_test.rb
+++ b/spec/benchmarks/big_o_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'benchmark_helper'
-require 'blueprinter/base'
+require 'blueprinter'
 require 'ostruct'
 
 class Blueprinter::BigOTest < Minitest::Benchmark

--- a/spec/benchmarks/ips_test.rb
+++ b/spec/benchmarks/ips_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'benchmark_helper'
-require 'blueprinter/base'
+require 'blueprinter'
 require 'ostruct'
 
 class Blueprinter::IPSTest < Minitest::Test

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |file| require file }
 
 module SpecHelpers
   def reset_blueprinter_config!
-    Blueprinter.instance_variable_set(:@configuration, nil)
+    Blueprinter.reset_configuration!
   end
 end
 

--- a/spec/units/association_spec.rb
+++ b/spec/units/association_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'blueprinter/association'
+
 describe Blueprinter::Association do
   describe '#initialize' do
     let(:blueprint) { Class.new(Blueprinter::Base) }

--- a/spec/units/blueprint_validator_spec.rb
+++ b/spec/units/blueprint_validator_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'blueprinter/blueprint_validator'
+
 describe Blueprinter::BlueprintValidator do
   describe 'validate!' do
     context 'when provided object subclasses Blueprinter::Base' do

--- a/spec/units/configuration_spec.rb
+++ b/spec/units/configuration_spec.rb
@@ -78,6 +78,7 @@ describe 'Blueprinter' do
     end
 
     it 'should default the `extractor_default` option' do
+      Blueprinter.reset_configuration!
       expect(Blueprinter.configuration.extractor_default).to eq(Blueprinter::AutoExtractor)
     end
 

--- a/spec/units/date_time_formatter_spec.rb
+++ b/spec/units/date_time_formatter_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'date'
+require 'blueprinter/formatters/date_time_formatter'
+
 describe '::DateTimeFormatter' do
   let(:formatter) { Blueprinter::DateTimeFormatter.new }
   let(:valid_date) { Date.new(1994, 3, 4) }

--- a/spec/units/deprecation_spec.rb
+++ b/spec/units/deprecation_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'blueprinter/deprecation'
+
 describe 'Blueprinter::Deprecation' do
   describe '#report' do
     TEST_MESSAGE = "Test Message"

--- a/spec/units/extensions_spec.rb
+++ b/spec/units/extensions_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'ostruct'
+require 'blueprinter/extensions'
 
 describe Blueprinter::Extensions do
   let(:all_extensions) {

--- a/spec/units/reflection_spec.rb
+++ b/spec/units/reflection_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'blueprinter/reflection'
+
 describe Blueprinter::Reflection do
   let(:category_blueprint) {
     Class.new(Blueprinter::Base) do

--- a/spec/units/view_collection_spec.rb
+++ b/spec/units/view_collection_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'blueprinter/view_collection'
+
 describe 'ViewCollection' do
   subject(:view_collection) { Blueprinter::ViewCollection.new }
 


### PR DESCRIPTION
Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [x] My build is green

Per #438, start using `autoload` for some things, and use `require 'blueprint/...` instead of `require_relative` in other places. This allows parts of the codebase to be loaded only if they're needed (Extensions, Transformers, V2, etc).

Based on feedback, the logic of `autoload` vs `require` is now:

- Use `autoload` for optional, top-level constants (`Base`, a future `V2`, `Extension`, `Transformer`, etc).
- Autoloaded files should `require` any constants they directly reference.
- Errors are an exception - we'll probably have an increasing number of them, so autoload makes IMHO.
- The above rules should ensure that nothing is autoloaded during render, except for errors.
