### PR TITLE
Fix Bug when using `if: Symbol` on Association

### DIFF
--- a/lib/blueprinter/association.rb
+++ b/lib/blueprinter/association.rb
@@ -11,18 +11,19 @@ module Blueprinter
     # @param name [Symbol] The name of the association as it will appear when rendered
     # @param blueprint [Blueprinter::Base] The blueprint to use for rendering the association
     # @param view [Symbol] The view to use in conjunction with the blueprint
+    # @param parent_blueprint [Blueprinter::Base] The blueprint that this association is being defined within
     # @param extractor [Blueprinter::Extractor] The extractor to use when retrieving the associated data
     # @param options [Hash]
     #
     # @return [Blueprinter::Association]
-    def initialize(method:, name:, blueprint:, view:, extractor: AssociationExtractor.new, options: {})
+    def initialize(method:, name:, blueprint:, view:, parent_blueprint:, extractor: AssociationExtractor.new, options: {})
       BlueprintValidator.validate!(blueprint)
 
       super(
         method,
         name,
         extractor,
-        blueprint,
+        parent_blueprint,
         options.merge(
           blueprint: blueprint,
           view: view,

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -156,6 +156,7 @@ module Blueprinter
         name: options.fetch(:name) { method },
         extractor: options.fetch(:extractor) { AssociationExtractor.new },
         blueprint: options.fetch(:blueprint),
+        parent_blueprint: self,
         view: options.fetch(:view, :default),
         options: options.except(
           :name,

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -420,6 +420,36 @@ shared_examples 'Base::render' do
     end
   end
 
+  context 'Given blueprint has fields with if conditional' do
+    let(:result) { '{"id":' + obj_id + '}' }
+    let(:blueprint) do
+      Class.new(Blueprinter::Base) do
+        identifier :id
+        field :first_name, if: ->(_field_name, _object, _local_opts) { false }
+      end
+    end
+    it 'does not render the field if condition is false' do
+      expect(blueprint.render(obj)).to eq(result)
+    end
+
+    context 'when if value is a symbol' do
+      let(:result) { '{"id":' + obj_id + '}' }
+      let(:blueprint) do
+        Class.new(Blueprinter::Base) do
+          identifier :id
+          field :first_name, if: :if_method
+
+          def self.if_method(_field_name, _object, _local_opts)
+            false
+          end
+        end
+      end
+      it 'does not render the field if the result of sending symbol to Blueprint is false' do
+        should eq(result)
+      end
+    end
+  end
+
   context 'Given blueprint has :meta without :root' do
     let(:blueprint) { blueprint_with_block }
     it('raises a BlueprinterError') {

--- a/spec/units/association_spec.rb
+++ b/spec/units/association_spec.rb
@@ -5,33 +5,42 @@ require 'blueprinter/association'
 describe Blueprinter::Association do
   describe '#initialize' do
     let(:blueprint) { Class.new(Blueprinter::Base) }
+    let(:parent_blueprint) { Class.new(Blueprinter::Base) }
+    let(:if_condition) { -> { true } }
     let(:args) do
       {
         method: :method,
         name: :name,
         extractor: :extractor,
         blueprint: blueprint,
+        parent_blueprint: parent_blueprint,
         view: :view,
-        options: { if: -> { true } }
+        options: { if: if_condition }
       }
     end
 
-    it 'returns an instance of Blueprinter::Association' do
-      expect(Blueprinter::Association.new(**args)).
-        to be_instance_of(Blueprinter::Association)
+    it 'returns an instance of Blueprinter::Association with expected values', aggregate_failures: true do
+      association = described_class.new(**args)
+      expect(association).to be_instance_of(described_class)
+      expect(association.method).to eq(:method)
+      expect(association.name).to eq(:name)
+      expect(association.extractor).to eq(:extractor)
+      expect(association.blueprint).to eq(parent_blueprint)
+      expect(association.options).to eq({ if: if_condition, blueprint: blueprint, view: :view, association: true })
     end
+
     context 'when provided :blueprint is invalid' do
       let(:blueprint) { Class.new }
 
       it 'raises a Blueprinter::InvalidBlueprintError' do
-        expect { Blueprinter::Association.new(**args) }.
+        expect { described_class.new(**args) }.
           to raise_error(Blueprinter::Errors::InvalidBlueprint)
       end
     end
 
     context 'when an extractor is not provided' do
       it 'defaults to using AssociationExtractor' do
-        expect(Blueprinter::Association.new(**args.except(:extractor)).extractor).
+        expect(described_class.new(**args.except(:extractor)).extractor).
           to be_an_instance_of(Blueprinter::AssociationExtractor)
       end
     end


### PR DESCRIPTION
Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->

## Background
Fixes #458 

## Changelog
- Update interface for `Assocation.new` to differentiate between the `Blueprint` that the association will be rendered using, and the `Blueprint` that the association is defined within (`parent_blueprint`). This resolves an issue where a `Symbol` `if:` option would be sent to the association's `Blueprint` instead of the parent `Blueprint`. 
- Add tests to address coverage gap for this functionality. 
