### PR TITLE
Fix typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Once a GitHub issue is accepted and assigned to you, please follow general workf
 
 1. Fork the target repository under your GitHub username.
 2. Create a branch in your forked repository for the changes you are about to make.
-3. Commit your changes in the branch you created in step 2. All commits need to be signed-off. Check the [legal](#legal) section bellow for more details.
+3. Commit your changes in the branch you created in step 2. All commits need to be signed-off. Check the [legal](#legal) section below for more details.
 4. Push your commits to your remote fork.
 5. Create a Pull Request from your remote fork pointing to the HEAD branch (usually `main` branch) of the target repository.
 6. Check the GitHub build and ensure that all checks are green.


### PR DESCRIPTION
I found a minor typo and fixed it.

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
