### PR TITLE
[Bug Fix] Fallback to :default view if nil is provided on reder

### DIFF
--- a/lib/blueprinter/helpers/base_helpers.rb
+++ b/lib/blueprinter/helpers/base_helpers.rb
@@ -15,7 +15,7 @@ module Blueprinter
       private
 
       def prepare_for_render(object, options)
-        view_name = options.fetch(:view, :default)
+        view_name = options.fetch(:view, :default) || :default
         root = options[:root]
         meta = options[:meta]
         validate_root_and_meta!(root, meta)

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -32,6 +32,29 @@ describe '::Base' do
   describe '::render' do
     subject { blueprint.render(obj) }
 
+    context 'when providing a view' do
+      let(:blueprint) do
+        Class.new(Blueprinter::Base) do
+          identifier :id
+          field :first_name
+
+          view :extended do
+            field :last_name
+          end
+        end
+      end
+      it 'renders the data based on the view definition' do
+        expect(blueprint.render(object_with_attributes, view: :extended)).
+          to eq('{"id":1,"first_name":"Meg","last_name":"Ryan"}')
+      end
+      context 'and the value is nil' do
+        it 'falls back to the :default view' do
+          expect(blueprint.render(object_with_attributes, view: nil)).
+            to eq(blueprint.render(object_with_attributes))
+        end
+      end
+    end
+
     context 'Outside Rails project' do
       context 'Given passed object has dot notation accessible attributes' do
         let(:obj) { object_with_attributes }
@@ -544,6 +567,7 @@ describe '::Base' do
       end
     end
   end
+
   describe '::render_as_hash' do
     subject { blueprint_with_block.render_as_hash(object_with_attributes) }
     context 'Outside Rails project' do


### PR DESCRIPTION
Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->

Fixes #471 

## Changelog
- Falls back to `:default` if `options` hash contains a `view` key, but the value is "false-y". 

## Follow Ups
The test suite has become a bit of a mess, and I fear that we're introducing unintended regressions as a result. Will open an issue to try rework/restructure the tests. 
