### PR TITLE
Allow a V2 view to specify its parent, regardless of how it's nested

### DIFF
--- a/lib/blueprinter/v2/dsl.rb
+++ b/lib/blueprinter/v2/dsl.rb
@@ -8,12 +8,13 @@ module Blueprinter
       # Define a new child view, which is a subclass of self.
       #
       # @param name [Symbol] Name of the view
+      # @param inherit [Symbol] Name of view to inherit from (default is the immediate inherit)
       # @yield Define the view in the block
       #
-      def view(name, &definition)
+      def view(name, inherit: nil, &definition)
         raise Errors::InvalidBlueprint, "View name may not contain '.'" if name.to_s =~ /\./
 
-        views[name.to_sym] = definition
+        views[name.to_sym] = ViewBuilder::Definition.new(definition, inherit)
       end
 
       #

--- a/spec/v2/view_builder_spec.rb
+++ b/spec/v2/view_builder_spec.rb
@@ -19,22 +19,24 @@ describe "Blueprinter::V2::ViewBuilder" do
 
   it "should store, but not evaluate, a view" do
     calls = 0
-    builder[:foo] =
+    builder[:foo] = Blueprinter::V2::ViewBuilder::Definition.new(
       proc do
         field :description
         calls += 1
       end
+    )
 
     expect(calls).to eq 0
   end
 
   it "should evaluate a view on first access" do
     calls = 0
-    builder[:foo] =
+    builder[:foo] = Blueprinter::V2::ViewBuilder::Definition.new(
       proc do
         field :description
         calls += 1
       end
+    )
 
     view = builder[:foo]
     builder[:foo]
@@ -43,7 +45,7 @@ describe "Blueprinter::V2::ViewBuilder" do
   end
 
   it "should fetch a view" do
-    builder[:foo] = proc { field :description }
+    builder[:foo] = Blueprinter::V2::ViewBuilder::Definition.new(proc { field :description })
 
     view = builder.fetch(:foo)
     expect(view.reflections[:default].fields.keys.sort).to eq %i(id name description).sort
@@ -54,10 +56,33 @@ describe "Blueprinter::V2::ViewBuilder" do
   end
 
   it "should iterate over each view" do
-    builder[:foo] = proc { field :description }
-    builder[:bar] = proc { field :description }
+    builder[:foo] = Blueprinter::V2::ViewBuilder::Definition.new(proc { field :description })
+    builder[:bar] = Blueprinter::V2::ViewBuilder::Definition.new(proc { field :description })
 
     keys = builder.each.map { |name, _| name }
     expect(keys.sort).to eq %i(default foo bar).sort
+  end
+
+  it 'should inherit from a different parent' do
+    blueprint = Class.new(Blueprinter::V2::Base) do
+      view :normal do
+        field :foo
+      end
+
+      view :normal2, inherit: :normal do
+        field :foo2
+      end
+
+      view :expanded do
+        field :bar
+
+        view :foo, inherit: :normal do
+          field :foo2
+        end
+      end
+    end
+
+    expect(blueprint.reflections[:normal2].fields.keys).to eq %i(foo foo2)
+    expect(blueprint.reflections[:"expanded.foo"].fields.keys).to eq %i(foo foo2)
   end
 end


### PR DESCRIPTION
I've been thinking about an "impendance mismatch" between V1 and V2 that will make upgrading more difficult (whether manual or scripted). This is an attempt to patch over a common case. I'm not 100% sold on it myself - I'd like to keep the DSL as simple as possible. Feedback welcome.

Consider the following V1 Blueprint:

```ruby
class WidgetBlueprint < Blueprinter::Base
  view :normal do
    field :name
  end

  view :extended do
    include_view :normal
    field :description
  end
end
```

There are currently two ways to represent this in V2: inheritance and partials.

```ruby
# Inheritance has the drawback that the extended view's name will change to
# "normal.extended". This will require callsites to be updated with the new name. 
class WidgetBlueprint < Blueprinter::V2::Base
  view :normal do
    field :name

    view :extended do
      field :description
    end
  end
end

# Using partials avoids that, but looks...not great. A converted codebase would be
# full of Blueprints defined like this:
class WidgetBlueprint < Blueprinter::V2::Base
  partial :normal do
    field :name
  end

  view :normal do
    use :normal
  end

  view :extended do
    use :normal
    field :description
  end
end
```

### What this PR adds

This PR allows a view to specify which view it should inherit from, without affecting the name:

```ruby
class WidgetBlueprint < Blueprinter::V2::Base
  view :normal do
    field :name
  end

  view :extended, inherit: :normal do
    field :description
  end
end
```

### Maybe a better idea??

Note that the above **doesn't** address cases where V1 views inherit from _multiple_ views. Those would still need to resort to partials. What if _every view implicitly defined a partial for itself_? 🤯 I think that would solve everything. [Much simpler to implement, too](https://github.com/procore-oss/blueprinter/compare/release-2.0...jh/implicit-partials).