### PR TITLE
Create an implicit partial for every V2 view

### DIFF
--- a/lib/blueprinter/v2/dsl.rb
+++ b/lib/blueprinter/v2/dsl.rb
@@ -13,7 +13,9 @@ module Blueprinter
       def view(name, &definition)
         raise Errors::InvalidBlueprint, "View name may not contain '.'" if name.to_s =~ /\./
 
-        views[name.to_sym] = definition
+        name = name.to_sym
+        partials[name] = definition
+        views[name] = definition
       end
 
       #

--- a/spec/v2/partials_spec.rb
+++ b/spec/v2/partials_spec.rb
@@ -84,4 +84,20 @@ describe "Blueprinter::V2 Partials" do
     end
     expect { blueprint[:foo] }.to raise_error(Blueprinter::Errors::UnknownPartial)
   end
+
+  it 'should create an implicit partial for every view' do
+    blueprint = Class.new(Blueprinter::V2::Base) do
+      view :foo do
+        field :name
+      end
+
+      view :bar do
+        use :foo
+        field :description
+      end
+    end
+
+    refs = blueprint.reflections
+    expect(refs[:bar].fields.keys).to eq %i(name description).sort
+  end
 end


### PR DESCRIPTION
I've been thinking about an impendance mismatch between V1 and V2 that will make upgrading more difficult (whether manual or scripted). This is an attempt to patch over it without changing any of V2's semantics. Curious what everyone thinks.

Consider the following V1 Blueprint:

```ruby
class WidgetBlueprint < Blueprinter::Base
  view :normal do
    field :name
  end

  view :extended do
    include_view :normal
    field :description
  end
end
```

There are currently two ways to represent this in V2: inheritance and partials.

```ruby
# Inheritance has the drawback that the extended view's name will change to
# "normal.extended". This will require callsites to be updated with the new name. 
class WidgetBlueprint < Blueprinter::V2::Base
  view :normal do
    field :name

    view :extended do
      field :description
    end
  end
end

# Using partials avoids that, but looks...not great. A converted codebase would be
# full of Blueprints defined like this:
class WidgetBlueprint < Blueprinter::V2::Base
  partial :normal do
    field :name
  end

  view :normal do
    use :normal
  end

  view :extended do
    use :normal
    field :description
  end
end
```

### What this PR adds

This PR automatically creates a partial for every view, allowing V2 to act much like V1 w/r/t to "including" other views.

```ruby
class WidgetBlueprint < Blueprinter::V2::Base
  view :normal do
    field :name
  end

  view :extended do
    use :normal
    field :description
  end
end
```