### PR TITLE
Feature: include original view in the options for custom field block

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,9 @@ _NOTE:_ `taskable.blueprint` should return a valid Blueprint class. Currently, `
 <summary>Defining A Field Directly In The Blueprint</summary>
 
 
-You can define a field directly in the Blueprint by passing it a block. This is especially useful if the object does not already have such an attribute or method defined, and you want to define it specifically for use with the Blueprint. This is done by passing `field` a block. The block also yields the object and any options that were passed from `render`. For example:
+You can define a field directly in the Blueprint by passing it a block. This is especially useful if the object does not already have such an attribute or method defined, and you want to define it specifically for use with the Blueprint. This is done by passing `field` a block. The block also yields the object and any options that were passed from `render` with, additionally,
+`view` which can be useful to access the view who triggered the field rendering (imagine view `a` include view `b`, during rendering of a generic field you can see view `a` on `options[:view]`).
+For example:
 
 ```ruby
 class UserBlueprint < Blueprinter::Base

--- a/README.md
+++ b/README.md
@@ -533,9 +533,7 @@ _NOTE:_ `taskable.blueprint` should return a valid Blueprint class. Currently, `
 <summary>Defining A Field Directly In The Blueprint</summary>
 
 
-You can define a field directly in the Blueprint by passing it a block. This is especially useful if the object does not already have such an attribute or method defined, and you want to define it specifically for use with the Blueprint. This is done by passing `field` a block. The block also yields the object and any options that were passed from `render` with, additionally,
-`view` which can be useful to access the view who triggered the field rendering (imagine view `a` include view `b`, during rendering of a generic field you can see view `a` on `options[:view]`).
-For example:
+You can define a field directly in the Blueprint by passing it a block. This is especially useful if the object does not already have such an attribute or method defined, and you want to define it specifically for use with the Blueprint. This is done by passing `field` a block. The block also yields the object and any options that were passed from `render`. For example:
 
 ```ruby
 class UserBlueprint < Blueprinter::Base
@@ -558,6 +556,44 @@ Output:
 {
   "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
   "full_name": "Mr John Doe"
+}
+```
+
+</details>
+
+<details>
+<summary>Accessing the View Option</summary>
+
+
+The `view` provided to the `render` call is implicitly available in the `options` hash within a `field` block, and can be referenced as needed. For example:
+
+```ruby
+class UserBlueprint < Blueprinter::Base
+  identifier :uuid
+  field :full_name do |user, options|
+    prefix = options[:view] == :admin ? '[Admin]' : options[:title_prefix]
+    "#{prefix} #{user.first_name} #{user.last_name}"
+  end
+
+  view :admin do
+    field :access_level
+  end
+end
+```
+
+Usage:
+
+```ruby
+puts UserBlueprint.render(user, title_prefix: "Mr", view: :admin)
+```
+
+Output:
+
+```json
+{
+  "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
+  "full_name": "[Admin] John Doe",
+  "access_level": "4"
 }
 ```
 

--- a/lib/blueprinter/rendering.rb
+++ b/lib/blueprinter/rendering.rb
@@ -122,7 +122,7 @@ module Blueprinter
       result_hash = view_collection.fields_for(view_name).each_with_object({}) do |field, hash|
         next if field.skip?(field.name, object, local_options)
 
-        value = field.extract(object, local_options)
+        value = field.extract(object, local_options.merge(view: view_name))
         next if value.nil? && field.options[:exclude_if_nil]
 
         hash[field.name] = value

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -516,6 +516,24 @@ shared_examples 'Base::render' do
     it('returns json with values derived from options') { should eq(result) }
   end
 
+  context 'Given ::render in a nested included view, original view is accessible in options' do
+    subject { blueprint.render(obj, view: :nested) }
+    let(:result) { '{"id":' + obj_id + ',"view_trigger":"nested"}' }
+    let(:blueprint) do
+      Class.new(Blueprinter::Base) do
+        identifier :id
+        field :view_trigger do |_obj, options|
+          "#{options[:view]}"
+        end
+
+        view :nested do
+          include_view :default
+        end
+      end
+    end
+    it('returns json with values derived from options') { should eq(result) }
+  end
+
   context 'Given blueprint has a transformer' do
     subject { blueprint.render(obj) }
     let(:result) { '{"id":' + obj_id + ',"full_name":"Meg Ryan"}' }

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -517,8 +517,6 @@ shared_examples 'Base::render' do
   end
 
   context 'Given ::render in a nested included view, original view is accessible in options' do
-    subject { blueprint.render(obj, view: :nested) }
-    let(:result) { '{"id":' + obj_id + ',"view_trigger":"nested"}' }
     let(:blueprint) do
       Class.new(Blueprinter::Base) do
         identifier :id
@@ -531,7 +529,27 @@ shared_examples 'Base::render' do
         end
       end
     end
-    it('returns json with values derived from options') { should eq(result) }
+
+    describe 'with non default view' do
+      subject { blueprint.render(obj, view: :nested) }
+      let(:result) { '{"id":' + obj_id + ',"view_trigger":"nested"}' }
+
+      it('returns json with values derived from options') { should eq(result) }
+    end
+
+    describe 'with explicit default view' do
+      subject { blueprint.render(obj, view: :default) }
+      let(:result) { '{"id":' + obj_id + ',"view_trigger":"default"}' }
+
+      it('returns json with values derived from options') { should eq(result) }
+    end
+
+    describe 'with non explicit default view' do
+      subject { blueprint.render(obj) }
+      let(:result) { '{"id":' + obj_id + ',"view_trigger":"default"}' }
+
+      it('returns json with values derived from options') { should eq(result) }
+    end
   end
 
   context 'Given blueprint has a transformer' do


### PR DESCRIPTION
The concept is simple, let's suppose there is a need of a custom object attribute, like:
```
view :default do
  field :property do |object, options|
    { foo: 'foo'}.merge(options[:view] == :nested ? { foo2: 'foo2' } : {})
  end
end

view :nested do
  # some other fields
end
```
Currently there is no way to see which view triggered the field rendering, the PR simply add the exposition of the triggering view inside options, to avoid the need of conditional rendering based on view to duplicate the code (cause currently i need to define a duplication inside a view of the default view custom field)

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
