### PR TITLE
Inherit views (V2)

### DIFF
--- a/lib/blueprinter/v2/base.rb
+++ b/lib/blueprinter/v2/base.rb
@@ -33,7 +33,7 @@ module Blueprinter
 
       # Initialize subclass
       def self.inherited(subclass)
-        subclass.views = ViewBuilder.new(subclass)
+        subclass.views = views.dup_for(subclass)
         subclass.schema = schema.transform_values(&:dup)
         subclass.excludes = []
         subclass.partials = partials.dup

--- a/lib/blueprinter/v2/base.rb
+++ b/lib/blueprinter/v2/base.rb
@@ -120,7 +120,7 @@ module Blueprinter
         extensions.freeze
         options.freeze
         schema.freeze
-        schema.each do |_, f|
+        schema.each_value do |f|
           f.options&.freeze
           f.freeze
         end

--- a/lib/blueprinter/v2/base.rb
+++ b/lib/blueprinter/v2/base.rb
@@ -117,6 +117,14 @@ module Blueprinter
         end
 
         excludes.each { |f| schema.delete f }
+        extensions.freeze
+        options.freeze
+        schema.freeze
+        schema.each do |_, f|
+          f.options&.freeze
+          f.freeze
+        end
+
         @evaled = true
       end
 

--- a/lib/blueprinter/v2/dsl.rb
+++ b/lib/blueprinter/v2/dsl.rb
@@ -8,14 +8,17 @@ module Blueprinter
       # Define a new child view, which is a subclass of self.
       #
       # @param name [Symbol] Name of the view
+      # @param fields [Boolean] Inherit fields from parents
+      # @param options [Boolean] Inherit options from parents
+      # @param extensions [Boolean] Inherit extensions from parents
       # @yield Define the view in the block
       #
-      def view(name, &definition)
+      def view(name, fields: true, options: true, extensions: true, &definition)
         raise Errors::InvalidBlueprint, "View name may not contain '.'" if name.to_s =~ /\./
 
         name = name.to_sym
         partials[name] = definition
-        views[name] = definition
+        views[name] = ViewBuilder::Def.new(definition:, fields:, options:, extensions:)
       end
 
       #

--- a/lib/blueprinter/v2/dsl.rb
+++ b/lib/blueprinter/v2/dsl.rb
@@ -5,7 +5,8 @@ module Blueprinter
     # Methods for defining Blueprint fields and views
     module DSL
       #
-      # Define a new child view, which is a subclass of self. If a view with this name already exists, the definition will be appended.
+      # Define a new child view, which is a subclass of self. If a view with this name already exists, the definition will be
+      # appended.
       #
       # @param name [Symbol] Name of the view
       # @param fields [Boolean] Inherit fields from parents (default true)

--- a/lib/blueprinter/v2/dsl.rb
+++ b/lib/blueprinter/v2/dsl.rb
@@ -5,15 +5,15 @@ module Blueprinter
     # Methods for defining Blueprint fields and views
     module DSL
       #
-      # Define a new child view, which is a subclass of self.
+      # Define a new child view, which is a subclass of self. If a view with this name already exists, the definition will be appended.
       #
       # @param name [Symbol] Name of the view
-      # @param fields [Boolean] Inherit fields from parents
-      # @param options [Boolean] Inherit options from parents
-      # @param extensions [Boolean] Inherit extensions from parents
+      # @param fields [Boolean] Inherit fields from parents (default true)
+      # @param options [Boolean] Inherit options from parents (default true)
+      # @param extensions [Boolean] Inherit extensions from parents (default true)
       # @yield Define the view in the block
       #
-      def view(name, fields: true, options: true, extensions: true, &definition)
+      def view(name, fields: nil, options: nil, extensions: nil, &definition)
         raise Errors::InvalidBlueprint, "View name may not contain '.'" if name.to_s =~ /\./
 
         name = name.to_sym
@@ -22,7 +22,7 @@ module Blueprinter
       end
 
       #
-      # Define a new partial.
+      # Define a new partial. If a partial with this name already exists, it will be replaced.
       #
       # @param name [Symbol] Name of the partial to create or import
       # @yield Define a new partial in the block

--- a/lib/blueprinter/v2/view_builder.rb
+++ b/lib/blueprinter/v2/view_builder.rb
@@ -26,7 +26,10 @@ module Blueprinter
       # @param definition [Proc]
       #
       def []=(name, definition)
-        @pending[name.to_sym] = definition
+        name = name.to_sym
+        raise Errors::InvalidBlueprint, 'You may not redefine the default view' if name == :default
+
+        @pending[name] = definition
       end
 
       #

--- a/lib/blueprinter/v2/view_builder.rb
+++ b/lib/blueprinter/v2/view_builder.rb
@@ -85,7 +85,7 @@ module Blueprinter
 
       private
 
-      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def build_view(name)
         defs = @pending[name]
         inherit_fields = defs.reduce(true) { |acc, d| d.fields.nil? ? acc : d.fields }
@@ -101,7 +101,7 @@ module Blueprinter
         defs.each { |d| view.class_eval(&d.definition) if d.definition }
         view
       end
-      # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     end
   end
 end

--- a/lib/blueprinter/v2/view_builder.rb
+++ b/lib/blueprinter/v2/view_builder.rb
@@ -30,7 +30,8 @@ module Blueprinter
         name = name.to_sym
         raise Errors::InvalidBlueprint, 'You may not redefine the default view' if name == :default
 
-        @pending[name] = definition
+        @pending[name] ||= []
+        @pending[name] << definition
       end
 
       #
@@ -45,14 +46,7 @@ module Blueprinter
           @mut.synchronize do
             next if @views.key?(name)
 
-            p = @pending[name]
-            view = Class.new(@parent)
-            view.views.reset
-            view.append_name(name)
-            view.schema.clear unless p.fields
-            view.options.clear unless p.options
-            view.extensions.clear unless p.extensions
-            view.class_eval(&p.definition) if p.definition
+            view = build_view name
             view.eval!(lock: false)
             @views[name] = view
           end
@@ -65,6 +59,7 @@ module Blueprinter
         self[name] || raise(KeyError, "View '#{name}' not found")
       end
 
+      # Yield each name and view
       def each(&block)
         enum = Enumerator.new do |y|
           y.yield(:default, self[:default])
@@ -76,7 +71,9 @@ module Blueprinter
       # Create a duplicate of this builder with a different default view
       def dup_for(blueprint)
         builder = self.class.new(blueprint)
-        @pending.each { |name, definition| builder[name] = definition }
+        @pending.each do |name, defs|
+          defs.each { |d| builder[name] = d }
+        end
         builder
       end
 
@@ -85,6 +82,26 @@ module Blueprinter
         @views = { default: @parent }
         @pending = {}
       end
+
+      private
+
+      # rubocop:disable Metrics/CyclomaticComplexity
+      def build_view(name)
+        defs = @pending[name]
+        inherit_fields = defs.reduce(true) { |acc, d| d.fields.nil? ? acc : d.fields }
+        inherit_options = defs.reduce(true) { |acc, d| d.options.nil? ? acc : d.options }
+        inherit_extensions = defs.reduce(true) { |acc, d| d.extensions.nil? ? acc : d.extensions }
+
+        view = Class.new(@parent)
+        view.views.reset
+        view.append_name(name)
+        view.schema.clear unless inherit_fields
+        view.options.clear unless inherit_options
+        view.extensions.clear unless inherit_extensions
+        defs.each { |d| view.class_eval(&d.definition) if d.definition }
+        view
+      end
+      # rubocop:enable Metrics/CyclomaticComplexity
     end
   end
 end

--- a/lib/blueprinter/v2/view_builder.rb
+++ b/lib/blueprinter/v2/view_builder.rb
@@ -11,6 +11,8 @@ module Blueprinter
     class ViewBuilder
       include Enumerable
 
+      Def = Struct.new(:definition, :fields, :options, :extensions, keyword_init: true)
+
       # @param parent [Class] A subclass of Blueprinter::V2::Base
       def initialize(parent)
         @parent = parent
@@ -22,7 +24,7 @@ module Blueprinter
       # Add a view definition.
       #
       # @param name [Symbol]
-      # @param definition [Proc]
+      # @param definition [Blueprinter::V2::ViewBuilder::Def]
       #
       def []=(name, definition)
         name = name.to_sym
@@ -43,10 +45,14 @@ module Blueprinter
           @mut.synchronize do
             next if @views.key?(name)
 
+            p = @pending[name]
             view = Class.new(@parent)
             view.views.reset
             view.append_name(name)
-            view.class_eval(&@pending[name]) if @pending[name]
+            view.schema.clear unless p.fields
+            view.options.clear unless p.options
+            view.extensions.clear unless p.extensions
+            view.class_eval(&p.definition) if p.definition
             view.eval!(lock: false)
             @views[name] = view
           end

--- a/spec/v2/view_builder_spec.rb
+++ b/spec/v2/view_builder_spec.rb
@@ -19,22 +19,22 @@ describe Blueprinter::V2::ViewBuilder do
 
   it "stores, but doesn't evaluates, a view" do
     calls = 0
-    builder[:foo] =
-      proc do
-        field :description
-        calls += 1
-      end
+    d = proc do
+      field :description
+      calls += 1
+    end
+    builder[:foo] = definition(d)
 
     expect(calls).to eq 0
   end
 
   it "evaluates a view on first access" do
     calls = 0
-    builder[:foo] =
-      proc do
-        field :description
-        calls += 1
-      end
+    d = proc do
+      field :description
+      calls += 1
+    end
+    builder[:foo] = definition(d)
 
     view = builder[:foo]
     builder[:foo]
@@ -43,7 +43,8 @@ describe Blueprinter::V2::ViewBuilder do
   end
 
   it "fetches a view" do
-    builder[:foo] = proc { field :description }
+    d = proc { field :description }
+    builder[:foo] = definition(d)
 
     view = builder.fetch(:foo)
     expect(view.reflections[:default].fields.keys.sort).to eq %i(id name description).sort
@@ -54,30 +55,35 @@ describe Blueprinter::V2::ViewBuilder do
   end
 
   it "iterates over each view" do
-    builder[:foo] = proc { field :description }
-    builder[:bar] = proc { field :description }
+    d = proc { field :description }
+    builder[:foo] = definition(d)
+    builder[:bar] = definition(d)
 
     keys = builder.each.map { |name, _| name }
     expect(keys.sort).to eq %i(default foo bar).sort
   end
 
   it "doesn't throw an error if you try to redefine an existing view" do
-    builder[:foo] = proc { field :description }
+    d = proc { field :description }
+    builder[:foo] = definition(d)
     expect do
-      builder[:foo] = proc { field :description }
+      d = proc { field :description }
+      builder[:foo] = definition(d)
     end.to_not raise_error
   end
 
   it "throws an error if you try to define the default view" do
+    d = proc { field :description }
     expect {
-      builder[:default] = proc { field :description }
+      builder[:default] = definition(d)
     }.to raise_error Blueprinter::Errors::InvalidBlueprint
   end
 
   context "reset" do
     it "clears all views but default" do
-      builder[:foo] = proc { field :description }
-      builder[:bar] = proc { field :description }
+      d = proc { field :description }
+      builder[:foo] = definition(d)
+      builder[:bar] = definition(d)
       builder.reset
 
       expect(builder[:foo]).to be_nil
@@ -90,8 +96,9 @@ describe Blueprinter::V2::ViewBuilder do
     let(:blueprint2) { Class.new(blueprint) { field :description } }
 
     it "duplicates views for another blueprint" do
-      builder[:foo] = proc { field :description }
-      builder[:bar] = proc { field :description }
+      d = proc { field :description }
+      builder[:foo] = definition(d)
+      builder[:bar] = definition(d)
       builder2 = builder.dup_for(blueprint2)
 
       expect(builder[:default]).to eq blueprint
@@ -99,5 +106,9 @@ describe Blueprinter::V2::ViewBuilder do
       expect(builder2[:foo]).to_not be_nil
       expect(builder2[:bar]).to_not be_nil
     end
+  end
+
+  def definition(definition)
+    described_class::Def.new(definition:, fields: true, options: true, extensions: true)
   end
 end

--- a/spec/v2/view_builder_spec.rb
+++ b/spec/v2/view_builder_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Blueprinter::V2::ViewBuilder" do
+describe Blueprinter::V2::ViewBuilder do
   let(:builder) do
     Blueprinter::V2::ViewBuilder.new(blueprint)
   end
@@ -59,5 +59,18 @@ describe "Blueprinter::V2::ViewBuilder" do
 
     keys = builder.each.map { |name, _| name }
     expect(keys.sort).to eq %i(default foo bar).sort
+  end
+
+  it "doesn't throw an error if you try to redefine an existing view" do
+    builder[:foo] = proc { field :description }
+    expect do
+      builder[:foo] = proc { field :description }
+    end.to_not raise_error
+  end
+
+  it "throws an error if you try to define the default view" do
+    expect {
+      builder[:default] = proc { field :description }
+    }.to raise_error Blueprinter::Errors::InvalidBlueprint
   end
 end

--- a/spec/v2/view_builder_spec.rb
+++ b/spec/v2/view_builder_spec.rb
@@ -73,4 +73,31 @@ describe Blueprinter::V2::ViewBuilder do
       builder[:default] = proc { field :description }
     }.to raise_error Blueprinter::Errors::InvalidBlueprint
   end
+
+  context "reset" do
+    it "clears all views but default" do
+      builder[:foo] = proc { field :description }
+      builder[:bar] = proc { field :description }
+      builder.reset
+
+      expect(builder[:foo]).to be_nil
+      expect(builder[:bar]).to be_nil
+      expect(builder[:default]).to eq blueprint
+    end
+  end
+
+  context "dup_for" do
+    let(:blueprint2) { Class.new(blueprint) { field :description } }
+
+    it "duplicates views for another blueprint" do
+      builder[:foo] = proc { field :description }
+      builder[:bar] = proc { field :description }
+      builder2 = builder.dup_for(blueprint2)
+
+      expect(builder[:default]).to eq blueprint
+      expect(builder2[:default]).to eq blueprint2
+      expect(builder2[:foo]).to_not be_nil
+      expect(builder2[:bar]).to_not be_nil
+    end
+  end
 end

--- a/spec/v2/view_spec.rb
+++ b/spec/v2/view_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+describe "Blueprinter::V2 Views" do
+  let(:blueprint) do
+    Class.new(Blueprinter::V2::Base) do
+      fields :id, :name
+
+      view :extended do
+        field :description
+
+        view :plus do
+          field :foo
+        end
+
+        view :plus2 do
+          field :price
+        end
+      end
+    end
+  end
+
+  it "are inherited by other blueprints" do
+    blueprint2 = Class.new(blueprint) do
+      view :foo do
+        field :foo
+      end
+    end
+    expect(blueprint2.reflections.keys.sort).to eq(%i[default extended extended.plus extended.plus2 foo])
+  end
+
+  it "are not inherited by other views" do
+    expect(blueprint[:"extended.plus2"].reflections.keys.sort).to eq(%i[default])
+  end
+end

--- a/spec/v2/view_spec.rb
+++ b/spec/v2/view_spec.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 describe "Blueprinter::V2 Views" do
+  let(:application_blueprint) do
+    Class.new(Blueprinter::V2::Base) do
+      fields :id, :timestamp
+    end
+  end
+
   let(:blueprint) do
     Class.new(Blueprinter::V2::Base) do
       fields :id, :name
@@ -30,5 +36,60 @@ describe "Blueprinter::V2 Views" do
 
   it "are not inherited by other views" do
     expect(blueprint[:"extended.plus2"].reflections.keys.sort).to eq(%i[default])
+  end
+
+  context "fields, options, and extensions" do
+    let(:application_blueprint) do
+      Class.new(Blueprinter::V2::Base) do
+        options[:exclude_if_nil] = true
+        extensions << Class.new(Blueprinter::Extension).new
+        fields :id
+        view(:identifier, fields: false) { field :id }
+      end
+    end
+
+    let(:blueprint) do
+      Class.new(application_blueprint) do
+        fields :name, :date
+
+        view :extended do
+          field :description
+        end
+
+        view :minimal, options: false, extensions: false
+      end
+    end
+
+    it "inherits fields by default" do
+      ref = blueprint.reflections
+      expect(ref[:default].fields.keys).to eq %i[id name date]
+      expect(ref[:extended].fields.keys).to eq %i[id name date description]
+    end
+
+    it "inherits options by default" do
+      expect(blueprint.options).to eq({exclude_if_nil: true})
+      expect(blueprint[:extended].options).to eq({exclude_if_nil: true})
+    end
+
+    it "inherits extensions by default" do
+      expect(blueprint.extensions.size).to eq 1
+      expect(blueprint[:extended].extensions.size).to eq 1
+    end
+
+    it "can opt out of inheriting fields" do
+      expect(application_blueprint.reflections[:identifier].fields.keys).to eq %i[id]
+    end
+
+    it "inherits views which opted out of inheriting fields" do
+      expect(blueprint.reflections[:identifier].fields.keys).to eq %i[id]
+    end
+
+    it "can opt out of inheriting options" do
+      expect(blueprint[:minimal].options).to eq({})
+    end
+
+    it "can opt out of inheriting extensions" do
+      expect(blueprint[:minimal].extensions).to eq([])
+    end
   end
 end

--- a/spec/v2/view_spec.rb
+++ b/spec/v2/view_spec.rb
@@ -91,5 +91,15 @@ describe "Blueprinter::V2 Views" do
     it "can opt out of inheriting extensions" do
       expect(blueprint[:minimal].extensions).to eq([])
     end
+
+    it "can be extended" do
+      bp1 = Class.new(Blueprinter::V2::Base) do
+        view(:foo) { fields :id, :name }
+      end
+      bp2 = Class.new(bp1) do
+        view(:foo) { field :description }
+      end
+      expect(bp2.reflections[:foo].fields.keys.sort).to eq %i(description id name)
+    end
   end
 end


### PR DESCRIPTION
### Changes:

- V2 blueprints inherit views from parents (like Legacy/V1)
- `view` options to skip inheriting certain attributes from the parent (i.e. fields, options, extensions)
- Freeze a blueprint/view's extensions, options and fields after it's first eval'd
- Disallow defining a `:default` view
- If a view is redefined, append to the existing definition instead of replacing it (like Legacy/V1)
  - If they **want** to replace it, they can do so using `view`'s new field/options/extension options

### Legacy/V1's "identifier" view can be emulated like this:

```ruby
class ApplicationBlueprint < Blueprinter::V2::Base
  field :id

  # without `fields: false`, this view would inherit fields from the top-level of child Blueprints
  view :identifier, fields: false do
    field :id
  end
end
```

