### PR TITLE
Add blueprinter_schema extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1029,6 +1029,7 @@ Extension hooks:
 Some known extensions are:
 
 * [blueprinter-activerecord](https://github.com/procore-oss/blueprinter-activerecord)
+* [blueprinter_schema](https://github.com/thisismydesign/blueprinter_schema)
 </details>
 
 <details>


### PR DESCRIPTION
I created an extension and would like to add it to your readme

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
