### PR TITLE
Pass options as keywords during block extraction

### DIFF
--- a/lib/blueprinter/extractors/block_extractor.rb
+++ b/lib/blueprinter/extractors/block_extractor.rb
@@ -6,7 +6,7 @@ module Blueprinter
   # @api private
   class BlockExtractor < Extractor
     def extract(_field_name, object, local_options, options = {})
-      options[:block].call(object, local_options)
+      options[:block].call(object, **local_options)
     end
   end
 end

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -516,6 +516,20 @@ shared_examples 'Base::render' do
     it('returns json with values derived from options') { should eq(result) }
   end
 
+  context 'Given ::render with options with keyword field option' do
+    subject { blueprint.render(obj, vehicle: vehicle) }
+    let(:result) { '{"id":' + obj_id + ',"vehicle_make":"Super Car"}' }
+    let(:blueprint) do
+      Class.new(Blueprinter::Base) do
+        identifier :id
+        field :vehicle_make do |_obj, vehicle:, **|
+          "#{vehicle[:make]}"
+        end
+      end
+    end
+    it('returns json with values derived from options') { should eq(result) }
+  end
+
   context 'Given ::render in a nested included view, original view is accessible in options' do
     let(:blueprint) do
       Class.new(Blueprinter::Base) do


### PR DESCRIPTION
Allows field definitions to use keyword options for blocks:

```ruby
  field :vehicle_make do |_obj, vehicle:, **|
    "#{vehicle[:make]}"
  end
```