### PR TITLE
[Patch] Add back .prepare method with a deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## Unreleased
 --
 
-## 1.2.0 - 2025/09/10
+## 1.2.1 - 2025/09/11
+- 🐛 [BUGFIX] Adds back `Blueprinter.prepare` method with a deprecated warning. This method was previously public, but was removed as part of **1.2.0**.
+
+## [REMOVED] 1.2.0 - 2025/09/10
 - ‼️ [BREAKING] Drops support for Ruby 3.0. See [#496](https://github.com/procore-oss/blueprinter/pull/496)
 - 💅 [ENHANCEMENT] Allows for the current view to be accessible from within the `options` hash provided to the `field` block. See [#503](https://github.com/procore-oss/blueprinter/pull/503). Thanks to [@neo87cs](https://github.com/neo87cs).
 - 🐛 [BUGFIX] Fixes an issue where specifying fields using a mix of symbols and strings would cause an `ArgumentError` when rendering. See [#505](https://github.com/procore-oss/blueprinter/pull/505). Thanks to [@lessthanjacob](https://github.com/lessthanjacob).

--- a/lib/blueprinter/rendering.rb
+++ b/lib/blueprinter/rendering.rb
@@ -96,6 +96,26 @@ module Blueprinter
       prepare_data(object, view_name, local_options)
     end
 
+    # @deprecated This method is no longer supported, and was not originally intended to be public. This will be removed
+    #   in the next minor release. If similar functionality is needed, use `.render_as_hash` instead.
+    #
+    # This is the magic method that converts complex objects into a simple hash
+    # ready for JSON conversion.
+    #
+    # Note: we accept view (public interface) that is in reality a view_name,
+    # so we rename it for clarity
+    #
+    # @api private
+    def prepare(object, view_name:, local_options:)
+      Blueprinter::Deprecation.report(
+        <<~MESSAGE
+          The `prepare` method is no longer supported will be removed in the next minor release.
+          If similar functionality is needed, use `.render_as_hash` instead.
+        MESSAGE
+      )
+      render_as_hash(object, view_name:, local_options:)
+    end
+
     private
 
     attr_reader :blueprint, :options

--- a/lib/blueprinter/version.rb
+++ b/lib/blueprinter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Blueprinter
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -580,6 +580,23 @@ describe '::Base' do
     end
   end
 
+  describe '.prepare' do
+    subject { blueprint_with_block.prepare(object_with_attributes, view_name: :default, local_options: {}) }
+    it 'returns a hash with expected format' do
+      expect(subject).to eq({ id: object_with_attributes.id, position_and_company: "#{object_with_attributes.position} at #{object_with_attributes.company}"})
+    end
+
+    it 'logs a deprecation warning' do
+      expect(Blueprinter::Deprecation).to receive(:report).with(
+        <<~MESSAGE
+          The `prepare` method is no longer supported will be removed in the next minor release.
+          If similar functionality is needed, use `.render_as_hash` instead.
+        MESSAGE
+      )
+      subject
+    end
+  end
+
   describe '::render_as_json' do
     subject { blueprint_with_block.render_as_json(object_with_attributes) }
     context 'Outside Rails project' do


### PR DESCRIPTION
Resolves #529.

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [x] My build is green

## Changelog
* Adds back `.prepare` method that was previously public on `Blueprinter::Base`. 
  * Given the `@api private` signifier, this method _should_ have been private. However, we shouldn't be removing public methods without proper notice. 
  * Calling `.prepare` now logs a deprecation warning.
* Bumps version to `1.2.1`. 

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
