### PR TITLE
Ensure Deprecation gets loaded before it's used

### DIFF
--- a/lib/blueprinter.rb
+++ b/lib/blueprinter.rb
@@ -4,6 +4,7 @@ module Blueprinter
   autoload :Base, 'blueprinter/base'
   autoload :BlueprinterError, 'blueprinter/blueprinter_error'
   autoload :Configuration, 'blueprinter/configuration'
+  autoload :Deprecation, 'blueprinter/deprecation'
   autoload :Errors, 'blueprinter/errors'
   autoload :Extension, 'blueprinter/extension'
   autoload :Transformer, 'blueprinter/transformer'

--- a/lib/blueprinter/rendering.rb
+++ b/lib/blueprinter/rendering.rb
@@ -2,6 +2,7 @@
 
 require 'blueprinter/errors/invalid_root'
 require 'blueprinter/errors/meta_requires_root'
+require 'blueprinter/deprecation'
 
 module Blueprinter
   # Encapsulates the rendering logic for Blueprinter.


### PR DESCRIPTION
I was testing some V2 stuff against our own codebase and hit a bug around `Blueprinter::Rendering#prepare`. Seems it's possible for `Deprecation` to not be loaded.