### PR TITLE
Fix cache invalidation after view block evaluation

### DIFF
--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -329,6 +329,7 @@ module Blueprinter
         self.view_scope = view_collection[view_name]
         view_collection[:default].track_definition_order(view_name)
         yield
+        view_collection.invalidate_cache!
         self.view_scope = view_collection[:default]
       end
 

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -133,6 +133,9 @@ module Blueprinter
       #   JSON output.
       # @option options [Symbol] :view Specify the view to use or fall back to
       #   to the :default view.
+      # @option options [Hash, Proc] :options Additional options to merge into the
+      #   options hash passed to the nested blueprint. Can be a static Hash or a Proc
+      #   that receives the parent object and returns a Hash.
       # @yield [object, options] The object and the options passed to render are
       #   also yielded to the block.
       #
@@ -148,6 +151,16 @@ module Blueprinter
       #     association :vehicles, blueprint: VehiclesBlueprint do |user, opts|
       #       user.vehicles + opts[:additional_vehicles]
       #     end
+      #   end
+      #
+      # @example Passing static options to the nested blueprint.
+      #   class UserBlueprint < Blueprinter::Base
+      #     association :vehicles, blueprint: VehiclesBlueprint, options: { show_owner: true }
+      #   end
+      #
+      # @example Passing dynamic options based on the parent object.
+      #   class UserBlueprint < Blueprinter::Base
+      #     association :vehicles, blueprint: VehiclesBlueprint, options: ->(user) { { owner_name: user.name } }
       #   end
       #
       # @return [Association] An object

--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -19,10 +19,11 @@ module Blueprinter
                                   options
                                 end
 
-      # Merge in assocation options hash
-      local_options = local_options.merge(options[:options]) if options[:options].is_a?(Hash)
       value = @extractor.extract(association_name, object, local_options, options_without_default)
       return default_value(options) if use_default_value?(value, options[:default_if])
+
+      # Merge in association options - supports both static Hash and dynamic Proc
+      local_options = merge_association_options(local_options, options[:options], object)
 
       view = options[:view] || :default
       blueprint = association_blueprint(options[:blueprint], value)
@@ -30,6 +31,18 @@ module Blueprinter
     end
 
     private
+
+    def merge_association_options(local_options, association_options, object)
+      return local_options unless association_options
+
+      additional_options = if association_options.respond_to?(:call)
+                             association_options.call(object)
+                           else
+                             association_options
+                           end
+
+      local_options.merge(additional_options)
+    end
 
     def default_value(association_options)
       return association_options.fetch(:default) if association_options.key?(:default)

--- a/lib/blueprinter/rendering.rb
+++ b/lib/blueprinter/rendering.rb
@@ -124,7 +124,7 @@ module Blueprinter
     def prepare_data(object, view_name, local_options)
       # Since we're currently providing the current view in the local_options hash when we extract fields, we can merge
       # it in ahead of time to avoid allocating a new hash for every field extraction.
-      local_options_with_view = local_options.merge(view: view_name).freeze
+      local_options_with_view = local_options.merge(view: view_name)
 
       if array_like?(object)
         object.map do |obj|

--- a/lib/blueprinter/view_collection.rb
+++ b/lib/blueprinter/view_collection.rb
@@ -37,6 +37,12 @@ module Blueprinter
         self[view_name].inherit(view)
       end
 
+      invalidate_cache!
+    end
+
+    # Clears the compiled field/transformer cache. This should be called after any mutation to a view's fields,
+    # exclusions, or transformers to ensure the cache reflects the current state.
+    def invalidate_cache!
       @cache = nil
     end
 
@@ -72,7 +78,7 @@ module Blueprinter
       @cache_mutex.synchronize do
         unless @views.key?(view_name)
           @views[view_name] = View.new(view_name)
-          @cache = nil
+          invalidate_cache!
         end
         @views[view_name]
       end

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -791,4 +791,30 @@ describe '::Base' do
       end
     end
   end
+
+  describe 'view block using reflections to dynamically exclude fields' do
+    let(:obj) { OpenStruct.new(id: 1, name: 'Widget', description: 'A widget', status: 'active') }
+
+    let(:blueprint) do
+      Class.new(Blueprinter::Base) do
+        identifier :id
+        fields :name, :description, :status
+
+        view :ids_only do
+          all_fields = reflections[:default].fields.keys.reject { |f| f == :id }
+          excludes(*all_fields)
+        end
+      end
+    end
+
+    it 'renders only the identifier for the ids_only view' do
+      result = blueprint.render_as_hash(obj, view: :ids_only)
+      expect(result.keys).to eq([:id])
+    end
+
+    it 'still renders all fields for the default view' do
+      result = blueprint.render_as_hash(obj)
+      expect(result.keys).to match_array([:id, :name, :description, :status])
+    end
+  end
 end

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -355,6 +355,22 @@ describe '::Base' do
           end
           it('returns json using the association options') { should eq(result) }
         end
+        context 'Given an association :options option with a Proc' do
+          let(:result) { '{"id":' + obj_id + ',"vehicles":[{"make":"Super Car (user_' + obj_id + ')"}]}' }
+          let(:blueprint) do
+            vehicle_blueprint = Class.new(Blueprinter::Base) do
+              field :make do |vehicle, options|
+                "#{vehicle.make} (#{options[:owner_id]})"
+              end
+            end
+
+            Class.new(Blueprinter::Base) do
+              field :id
+              association :vehicles, blueprint: vehicle_blueprint, options: ->(obj) { { owner_id: "user_#{obj.id}" } }
+            end
+          end
+          it('returns json using the dynamic association options') { should eq(result) }
+        end
         context 'Given an association :extractor option' do
           let(:result) { '{"id":' + obj_id + ',"vehicles":[{"make":"SUPER CAR"}]}' }
           let(:blueprint) do

--- a/spec/units/view_collection_spec.rb
+++ b/spec/units/view_collection_spec.rb
@@ -219,5 +219,20 @@ describe 'ViewCollection' do
       expect(fields_after).not_to equal(fields_before)
       expect(fields_after).to eq(fields_before)
     end
+
+    it 'invalidates cache when invalidate_cache! is called after view mutation' do
+      # Build the cache by accessing fields
+      fields_before = view_collection.fields_for(:view)
+      expect(fields_before).to include(default_field, view_field)
+
+      # Mutate the view after cache is built (simulates excludes inside a view block)
+      view.exclude_field(:default_field)
+      view_collection.invalidate_cache!
+
+      # Cache should rebuild with the exclusion applied
+      fields_after = view_collection.fields_for(:view)
+      expect(fields_after).not_to include(default_field)
+      expect(fields_after).to include(view_field)
+    end
   end
 end


### PR DESCRIPTION
## Summary

This PR contains multiple fixes for the Blueprinter 1.3.0 release:

1. **Cache invalidation after view block evaluation** - Fixes a bug where the ViewCollection cache could be prematurely compiled during view block evaluation (e.g. when `reflections` is called inside a `view` block), causing subsequent mutations like `excludes` to be silently lost.

2. **Remove freeze on local_options** - Reverts the `.freeze` call on `local_options` that was preventing transformers from mutating options to pass derived values to downstream fields.

3. **Support Proc for association `:options` parameter** - Allows passing a Proc that receives the parent object and returns a Hash to merge into options for the nested blueprint. This enables dynamic options without relying on mutation inside association blocks.

## Context

Discovered during blueprinter 1.3.0 upgrade testing in the Procore monolith.

### Cache invalidation issue
The `ids_only` view pattern uses `reflections[:default].fields.keys` inside a view block to dynamically exclude all non-identifier fields. This triggers `ensure_cached!` which freezes the cache before the `excludes` call runs.

### Options mutation issue
PR #521 changed block extraction to use keyword arguments (`**local_options`), which creates a copy of the hash. This broke patterns that mutated options inside association blocks expecting nested blueprints to see the change:

```ruby
# Before (relied on mutation, broken by keyword args change)
association :author, blueprint: UserBlueprint, view: :with_company do |post, options|
  options[:company] = post.company
  post.author
end

# After (explicit, works with keyword args)
association :author,
  blueprint: UserBlueprint,
  view: :with_company,
  options: ->(post) { { company: post.company } }
```

## Test plan

- [x] Unit test: `invalidate_cache!` after view mutation correctly rebuilds cache
- [x] Integration test: `reflections` inside view block with `excludes` produces correct output
- [x] Integration test: association with `options:` Proc passes dynamic options to nested blueprint
- [x] Full suite: 393 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.ai/code)