### PR TITLE
Update README to reflect v1.3.0 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Test](https://github.com/procore-oss/blueprinter/actions/workflows/test.yaml/badge.svg?branch=master)](https://github.com/procore-oss/blueprinter/actions/workflows/test.yaml)
+[![Test](https://github.com/procore-oss/blueprinter/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/procore-oss/blueprinter/actions/workflows/test.yaml)
 [![Gem Version](https://badge.fury.io/rb/blueprinter.svg)](https://badge.fury.io/rb/blueprinter)
 [![Discord](https://img.shields.io/badge/Chat-EDEDED?logo=discord)](https://discord.gg/PbntEMmWws)
 
@@ -428,6 +428,21 @@ class DriverBlueprint < Blueprinter::Base
 end
 ```
 
+The `options` parameter also accepts a `Proc` (or any callable) for cases where the options need to be derived from the parent object at render time. The callable is invoked with the parent object and must return a Hash, which is then merged into the options passed to the associated Blueprint.
+
+```ruby
+class DriverBlueprint < Blueprinter::Base
+  identifier :uuid
+
+  view :normal do
+    fields :first_name, :last_name
+    association :vehicles,
+                blueprint: VehicleBlueprint,
+                options: ->(driver) { { trim: driver.preferred_trim } }
+  end
+end
+```
+
 </details>
 
 <details>
@@ -559,6 +574,25 @@ Output:
 }
 ```
 
+When a field block just delegates to a single method on the object, `Symbol#to_proc` (`&:method_name`) can be used as a terser form of the block syntax:
+
+```ruby
+class UserBlueprint < Blueprinter::Base
+  identifier :uuid
+  field :display_name, &:formatted_full_name
+end
+```
+
+This is equivalent to:
+
+```ruby
+field :display_name do |user|
+  user.formatted_full_name
+end
+```
+
+_NOTE:_ When using `Symbol#to_proc`, the block is invoked with only the object — `options` are not available, and the configured extractor is bypassed. For simple renames of an existing attribute, prefer the `name:` option instead (see [Renaming](#renaming)), which routes through the configured extractor and keeps the DSL consistent.
+
 </details>
 
 <details>
@@ -626,6 +660,16 @@ Output:
   "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
 }
 ```
+
+Identifiers also accept `Symbol#to_proc` shorthand as a terser form of the block syntax when the value is a single method call on the object:
+
+```ruby
+class UserBlueprint < Blueprinter::Base
+  identifier :anonymized_id, &:obfuscated_uuid
+end
+```
+
+_NOTE:_ As with fields, this bypasses the configured extractor and does not have access to `options`. To use a different key name than the underlying method (without a block), use `identifier :method_name, name: :key_name`.
 
 </details>
 


### PR DESCRIPTION
## Summary

Updates the README to reflect changes shipped in v1.3.0 and fixes a stale CI badge.

### Changes

- **Fix CI badge branch.** The `Test` badge was querying `?branch=master`, but the default branch is `main`. Updated so the badge reflects current CI state.
- **Document `Symbol#to_proc` shorthand for fields and identifiers** ([#546](https://github.com/procore-oss/blueprinter/pull/546)). Added a note in both the "Defining A Field Directly In The Blueprint" and "Defining An Identifier Directly In The Blueprint" sections showing the `field :foo, &:bar` / `identifier :foo, &:bar` form, with a caveat that `options` aren't available and the configured extractor is bypassed. Also points users toward `name:` for pure renames so the DSL remains consistent.
- **Document `Proc` support for association `:options`** ([#579](https://github.com/procore-oss/blueprinter/pull/579)). Added an example to the Associations section showing `options: ->(parent) { ... }` for cases where options need to be derived from the parent object at render time.

No functional code changes — docs only.

## Test plan

- [x] Verify the CI badge renders correctly on the rendered README
- [x] Verify the `#renaming` anchor link in the field section resolves
- [x] Skim the rendered Markdown for formatting/collapsible-section correctness

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->