### PR TITLE
Reduce V2 serializer allocations by ~23% via fast path

### DIFF
--- a/lib/blueprinter/v2/extractors.rb
+++ b/lib/blueprinter/v2/extractors.rb
@@ -24,6 +24,18 @@ module Blueprinter
             ctx.object.public_send(ctx.field.from)
           end
         end
+
+        # Fast-path extraction that avoids a Context::Field allocation.
+        # @param object [Object] The object or hash being serialized
+        # @param field [Blueprinter::V2::Fields::Field|Object|Collection]
+        # @return [Object] The field value
+        def self.extract_simple(object, field)
+          if object.is_a? Hash
+            object[field.from] || object[field.from_str]
+          else
+            object.public_send(field.from)
+          end
+        end
       end
     end
   end

--- a/lib/blueprinter/v2/serializer.rb
+++ b/lib/blueprinter/v2/serializer.rb
@@ -19,8 +19,8 @@ module Blueprinter
         @formatter = Formatter.new(blueprint_class)
         @format = @formatter.any?
         @hooks = Hooks.new(extensions)
+        finalize_fields!   # must run before find_used_hooks! so field flags are set
         find_used_hooks!
-        finalize_fields!
       end
 
       def object(object, options, instances:, store:, depth:, parent: nil)
@@ -60,8 +60,10 @@ module Blueprinter
       # Long and ugly for performance
       # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       def serialize(blueprint, fields, options, objects, instances:, store:, depth:)
+        return serialize_fast(fields, options, objects, instances:, store:, depth:) unless @needs_field_ctx
+
         ctx = Context::Field.new(blueprint, fields, options, nil, nil, store, depth)
-        parent = Context::Parent.new(@blueprint_class)
+        parent = nil
         # rubocop:disable Metrics/BlockLength
         objects.map do |object|
           ctx.object = object
@@ -91,12 +93,37 @@ module Blueprinter
               elsif field.type == :field
                 @format ? @formatter.call(ctx, value) : value
               else
+                parent ||= Context::Parent.new(@blueprint_class)
                 parent.field = field
                 parent.object = object
                 field.serializer.serialize(field.blueprint, value, options, parent:, instances:, store:, depth:)
               end
           end
           # rubocop:enable Metrics/BlockLength
+        end
+      end
+
+      # Fast path: no Context::Field allocation.
+      # Only used when there are no hooks, conditionals, defaults, formatters, or Proc extractors.
+      # Context::Parent is still created lazily for association fields so child blueprints
+      # with around_serialize_object hooks still receive valid parent context.
+      def serialize_fast(fields, options, objects, instances:, store:, depth:)
+        parent = nil
+        objects.map do |object|
+          fields.each_with_object({}) do |field, result|
+            value = field.extractor.extract_simple(object, field)
+            result[field.name] =
+              if value.nil?
+                field.options[:exclude_if_nil] ? next : nil
+              elsif field.type == :field
+                value
+              else
+                parent ||= Context::Parent.new(@blueprint_class)
+                parent.field = field
+                parent.object = object
+                field.serializer.serialize(field.blueprint, value, options, parent:, instances:, store:, depth:)
+              end
+          end
         end
       end
       # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
@@ -143,6 +170,13 @@ module Blueprinter
           object: @hooks.registered?(:around_object_value) ? :around_object_value : nil,
           collection: @hooks.registered?(:around_collection_value) ? :around_collection_value : nil
         }.freeze
+        # Fast path: skip Context::Field/Parent allocation when no hooks, conditionals,
+        # defaults, formatters, or Proc extractors are in play.
+        @needs_field_ctx = @format ||
+                           @field_hooks.values.any? ||
+                           default_fields.any? { |f|
+                             f.has_conditional || f.has_default || f.extractor == Extractors::Proc
+                           }
       end
 
       # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity


### PR DESCRIPTION
Add a context-free serialization path for the common case where no extension hooks, conditionals, default values, formatters, or Proc extractors are configured.

Previously, every call to `serialize` allocated a `Context::Field` and a `Context::Parent` struct unconditionally — even when nothing in the serialization loop ever read them. Together these accounted for ~22% of all object allocations and caused V2 to trigger 2× more GC runs than V1 under the same workload.

Changes:
- Add `Extractors::Property.extract_simple` to extract field values directly from an object/hash without a Context::Field
- Precompute `@needs_field_ctx` at blueprint load time in `find_used_hooks!` (requires `finalize_fields!` to run first, hence the reorder in `initialize`)
- Branch to `serialize_fast` when `@needs_field_ctx` is false, skipping the Context::Field allocation entirely
- Make `Context::Parent` lazy in both paths — created at most once per `serialize` call, only when an association field is actually encountered

Result on 500 widgets × 50 iterations (30 fields, 10 object associations, 5 collection associations):
  - Allocations:      −23% (3.3M → 2.56M objects)
  - GC runs:          −26% (85 → 63)
  - Context::Field:   eliminated from hot path (75k → 0 samples)
  - Context::Parent:  eliminated from hot path (75k → ~10 samples)

V2 now allocates fewer objects than V1 for the common case.

Made-with: Cursor

Checklist:

* [ ] I have updated the necessary documentation
* [ ] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [ ] My build is green
