### PR TITLE
feat: raise Errors::UnknownView for missing render view

### DIFF
--- a/lib/blueprinter/errors.rb
+++ b/lib/blueprinter/errors.rb
@@ -3,5 +3,6 @@
 module Blueprinter
   module Errors
     autoload :InvalidBlueprint, 'blueprinter/errors/invalid_blueprint'
+    autoload :UnknownView, 'blueprinter/errors/unknown_view'
   end
 end

--- a/lib/blueprinter/errors/unknown_view.rb
+++ b/lib/blueprinter/errors/unknown_view.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Blueprinter
+  module Errors
+    class UnknownView < BlueprinterError; end
+  end
+end

--- a/lib/blueprinter/rendering.rb
+++ b/lib/blueprinter/rendering.rb
@@ -2,6 +2,7 @@
 
 require 'blueprinter/errors/invalid_root'
 require 'blueprinter/errors/meta_requires_root'
+require 'blueprinter/errors/unknown_view'
 require 'blueprinter/deprecation'
 
 module Blueprinter
@@ -91,7 +92,7 @@ module Blueprinter
     #   additional key value pairs will be exposed during serialization.
     # @return [Hash]
     def hashify(object, view_name:, local_options:)
-      raise BlueprinterError, "View '#{view_name}' is not defined" unless view_collection.view?(view_name)
+      raise Errors::UnknownView, "View '#{view_name}' is not defined" unless view_collection.view?(view_name)
 
       object = Blueprinter.configuration.extensions.pre_render(object, self, view_name, local_options)
       prepare_data(object, view_name, local_options)

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -53,6 +53,16 @@ describe '::Base' do
             to eq(blueprint.render(object_with_attributes))
         end
       end
+      context 'and the view is not defined' do
+        it 'raises Errors::UnknownView' do
+          expect { blueprint.render(object_with_attributes, view: :missing) }.
+            to raise_error(Blueprinter::Errors::UnknownView, "View 'missing' is not defined")
+        end
+        it 'remains rescuable as BlueprinterError' do
+          expect { blueprint.render(object_with_attributes, view: :missing) }.
+            to raise_error(Blueprinter::BlueprinterError)
+        end
+      end
     end
 
     context 'when using Symbol#to_proc syntax' do


### PR DESCRIPTION
Adds `Blueprinter::Errors::UnknownView`, raised by `Rendering#hashify` when the requested view does not exist. It inherits from `BlueprinterError` so existing rescue blocks keep working, and lets callers distinguish a 400 (caller-supplied bad view name) from a 500 (any other `BlueprinterError`). This ports the V2 class forward as suggested in #569.

Closes #569

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
