### PR TITLE
Extensions must register hooks in their initializers

### DIFF
--- a/docs/extensions/basics.md
+++ b/docs/extensions/basics.md
@@ -1,10 +1,14 @@
 # Basics
 
-An extension will subclass `Blueprinter::Extension` and define one or more hook methods. (See `Blueprinter::Extension` for documentation about all hooks.)
+An extension will subclass `Blueprinter::Extension` then define and register one or more hooks. (See `Blueprinter::Extension` for documentation about all hooks.)
 
 ```ruby
-class ExcludeIfBlankExtension < Blueprinter::Extension
-  def around_field_value(ctx)
+class ExcludeIfBlank < Blueprinter::Extension
+  def initialize
+    around_field_value :skip_blank
+  end
+  
+  def skip_blank(ctx)
     # get the value by yielding to other extensions and Blueprinter's internals
     val = yield ctx
 
@@ -21,7 +25,7 @@ Then add the extension to a blueprint:
 
 ```ruby
 class MyBlueprint < Blueprinter::V2::Base
-  add ExcludeIfBlankExtension.new
+  add ExcludeIfBlank.new
 
   field :name, exclude_if_blank: true
 end

--- a/docs/extensions/blueprint-decorator.md
+++ b/docs/extensions/blueprint-decorator.md
@@ -3,14 +3,15 @@
 This example adds metadata to the output of a Blueprint, similar to Legacy/V1's transformer feature.
 
 ```ruby
-class DecoratorExtension < Blueprinter::Extension
+class BlueprintDecorator < Blueprinter::Extension
   def initialize(attr, &decorator)
     @attr = attr
     @decorator = decorator
+    around_blueprint :decorate
   end
 
   # @param ctx [Blueprinter::V2::Context::Object]
-  def around_blueprint(ctx)
+  def decorate(ctx)
     result = yield ctx
     result[@attr] = @decorator.call(ctx.object)
     result
@@ -22,7 +23,7 @@ Add the extension to whatever blueprints need metadata:
 
 ```ruby
 class MyBlueprint < ApplicationBlueprint
-  add DecoratorExtension.new(:metadata) { |object|
+  add BlueprintDecorator.new(:metadata) { |object|
     # extract and return metadata from the object
   }
 end

--- a/docs/extensions/camelize-fields.md
+++ b/docs/extensions/camelize-fields.md
@@ -4,9 +4,13 @@ This example alters the `source` of each field to use camel case, leaving the se
 
 ```ruby
 class CamelizedSourceExtension < Blueprinter::Extension
-  def around_blueprint_init(ctx)
+  def initialize
+    around_blueprint_init :camelize_fields
+  end
+  
+  def camelize_fields(ctx)
     ctx.fields.each do |field|
-      field.source = field.source.to_s.camelize(:lower).to_sym
+      field.source = field.source_str.camelize(:lower).to_sym
     end
     yield ctx
   end

--- a/docs/extensions/custom-extractor.md
+++ b/docs/extensions/custom-extractor.md
@@ -9,10 +9,13 @@ class CustomExtractor < Blueprinter::Extension
   def initialize(klass, &extractor)
     @klass = klass
     @extractor = extractor
+    around_field_value :extract
+    around_object_value :extract
+    around_collection_value :extract
   end
   
   # @param ctx [Blueprinter::V2::Context::Field]
-  def around_field_value(ctx)
+  def extract(ctx)
     if ctx.object.is_a? @klass
       # Use custom extraction
       @extractor.call(ctx.field.source, ctx.object)
@@ -21,10 +24,6 @@ class CustomExtractor < Blueprinter::Extension
       yield ctx
     end
   end
-
-  # Same behavior for associations
-  alias around_object_value around_field_value
-  alias around_collection_value around_field_value
 end
 ```
 

--- a/docs/extensions/exclude-if-blank.md
+++ b/docs/extensions/exclude-if-blank.md
@@ -6,9 +6,13 @@ It works just like the built-in `exclude_if_nil` option, but checks for `blank?`
 options first, then allows fields to override it.
 
 ```ruby
-class ExcludeIfBlankExtension < Blueprinter::Extension
+class ExcludeIfBlank < Blueprinter::Extension
+  def initialize
+    around_field_value :skip_blank
+  end
+  
   # @param ctx [Blueprinter::V2::Context::Field]
-  def around_field_value(ctx)
+  def skip_blank(ctx)
     val = yield ctx
 
     exclude = ctx.blueprint.options[:exclude_if_blank]
@@ -24,7 +28,7 @@ Add it to your `ApplicationBlueprint` and use it in your blueprints.
 
 ```ruby
 class ApplicationBlueprint < Blueprinter::V2::Base
-  add ExcludeIfBlankExtension.new
+  add ExcludeIfBlank.new
 end
 ```
 

--- a/docs/extensions/performance.md
+++ b/docs/extensions/performance.md
@@ -20,8 +20,14 @@ The `around_field_value` hook and friends are the simplest way to implement it:
 
 ```ruby
 class CamelCaseSource < Blueprinter::Extension
+  def initialize
+    around_field_value :camelize
+    around_object_value :camelize
+    around_collection_value :camelize
+  end
+
   # @param ctx [Blueprinter::V2::Context::Field]
-  def around_field_value(ctx)
+  def camelize(ctx)
     attr = ctx.field.source_str.camelize
     if ctx.object.is_a? Hash
       ctx.object.key?(attr) ? ctx.object[attr] : ctx.object[attr.to_sym]
@@ -29,9 +35,6 @@ class CamelCaseSource < Blueprinter::Extension
       ctx.object.public_send(attr)
     end
   end
-
-  alias around_object_value around_field_value
-  alias around_collection_value around_field_value
 end
 ```
 
@@ -74,8 +77,12 @@ What if we could alter the field definitions programatically, before anything is
 
 ```ruby
 class CamelCaseSource < Blueprinter::Extension
+  def initialize
+    around_blueprint_init :camelize
+  end
+
   # @param ctx [Blueprinter::V2::Context::Init]
-  def around_blueprint_init(ctx)
+  def camelize(ctx)
     ctx.fields.each do |field|
       field.source = field.source_str.camelize.to_sym
     end

--- a/docs/extensions/performance.md
+++ b/docs/extensions/performance.md
@@ -16,30 +16,26 @@ But that's tedious and error-prone. Let's write an extension to do it for us.
 
 ### Manually extract each field
 
-The `around_field_value` hook and friends are the simplest way to implement it:
+The `around_field_value` hook and friends are the simplest way to implement it, by extracting the value ourselves:
 
 ```ruby
-class CamelCaseSource < Blueprinter::Extension
+class CamelCaseExtractor < Blueprinter::Extension
   def initialize
-    around_field_value :camelize
-    around_object_value :camelize
-    around_collection_value :camelize
+    around_field_value :extract
+    around_object_value :extract
+    around_collection_value :extract
   end
 
   # @param ctx [Blueprinter::V2::Context::Field]
-  def camelize(ctx)
+  def extract(ctx)
     attr = ctx.field.source_str.camelize
-    if ctx.object.is_a? Hash
-      ctx.object.key?(attr) ? ctx.object[attr] : ctx.object[attr.to_sym]
-    else
-      ctx.object.public_send(attr)
-    end
+    ctx.object.public_send(attr)
   end
 end
 ```
 
 But what about the performance? These hooks will run for _every field_ on the Blueprint. If you're adding this extension only to specific Blueprints that might be fine.
-But what if someone adds it to `ApplicationBlueprint`? Then it will run for _every field in every Blueprint_ in your application!
+But what if your entire application needs it? That's a lot of overhead for something so basic.
 
 ### Transform each Blueprint's result
 
@@ -52,12 +48,14 @@ field :someField
 Then we can convert the output to snake case:
 
 ```ruby
-class CamelCaseSource < Blueprinter::Extension
+class SnakeCaseTransformer < Blueprinter::Extension
+  def initialize
+    around_blueprint :transform
+  end
+  
   # @param ctx [Blueprinter::V2::Context::Object]
-  def around_blueprint(ctx)
-    # Get the serialized output from Blueprinter
+  def transform(ctx)
     result = yield ctx
-    # Convert it
     snake_case result
     result
   end
@@ -76,18 +74,18 @@ This runs only once per serialized object, so it's a big improvement. But that c
 What if we could alter the field definitions programatically, before anything is serialized? The `around_blueprint_init` hook runs only _once per Blueprint_ during a render. It's quite cheap, and it can alter field definitions.
 
 ```ruby
-class CamelCaseSource < Blueprinter::Extension
+class SourceCamelizer < Blueprinter::Extension
   def initialize
-    around_blueprint_init :camelize
+    around_blueprint_init :camelize_sources
   end
 
   # @param ctx [Blueprinter::V2::Context::Init]
-  def camelize(ctx)
+  def camelize_sources(ctx)
     ctx.fields.each do |field|
-      field.source = field.source_str.camelize.to_sym
+      # Camelize the `source` attribute of each field
+      field.source = field.source_str.camelize(:lower).to_sym
     end
     yield ctx
   end
+end
 ```
-
-This is effectively the same as setting `source` on each field in the Blueprint. There's essentially zero runtime cost.

--- a/docs/extensions/telemetry.md
+++ b/docs/extensions/telemetry.md
@@ -4,13 +4,16 @@ Blueprinter bundles the `Blueprinter::Extensions::OpenTelemetry` extension. But 
 
 ```ruby
 class MyTelemetryExtension
-  def initialize(my_tel)
+  def initialize(my_tel, trace_extensions: true)
     @my_tel = my_tel
+    around_serialize_object :trace_object
+    around_serialize_collection :trace_collection
+    around_hook :trace_hook if trace_extensions
   end
 
   # Create a span for object serialization
   # @param ctx [Blueprinter::V2::Context::Object]
-  def around_serialize_object(ctx)
+  def trace_object(ctx)
     @my_tel.span("blueprint.object", blueprint: ctx.blueprint.to_s) do
       yield ctx
     end
@@ -18,7 +21,7 @@ class MyTelemetryExtension
 
   # Create a span for collection serialization
   # @param ctx [Blueprinter::V2::Context::Object]
-  def around_serialize_collection(ctx)
+  def trace_collection(ctx)
     @my_tel.span("blueprint.collection", blueprint: ctx.blueprint.to_s) do
       yield ctx
     end
@@ -26,7 +29,7 @@ class MyTelemetryExtension
 
   # Create a span for other extension hooks
   # @param ctx [Blueprinter::V2::Context::Hook]
-  def around_hook(ctx)
+  def trace_hook(ctx)
     @my_tel.span("blueprint.extension", extension: ctx.extension.class.name, hook: ctx.hook) do
       yield
     end

--- a/docs/extensions/yaml-serializer.md
+++ b/docs/extensions/yaml-serializer.md
@@ -4,7 +4,11 @@ This example adds YAML to Blueprinter. Why? Because we can.
 
 ```ruby
 class YamlSerializerExtension < Blueprinter::Extension
-  def around_result(ctx)
+  def initialize
+    around_result :serialize
+  end
+  
+  def serialize(ctx)
     case ctx.format
     when :yaml
       # Get the Hash/Array result

--- a/docs/v2/breaking/extensions.md
+++ b/docs/v2/breaking/extensions.md
@@ -9,17 +9,22 @@ Here's an example of an extension that supports both V1 and V2:
 
 ```ruby
 class MyExtension < Blueprinter::Extension
-  # V1 API
-  def pre_render(object, blueprint_class, view, options)
-    modify(object, blueprint_class, view, options)
+  def initialize
+    # Register 'modify_object' as a V2 around_result hook
+    around_result :modify_object
   end
 
   # V2 API
-  def around_result(ctx)
+  def modify_object(ctx)
     blueprint_class = ctx.blueprint.class
     view = blueprint_class.view_name
     ctx.object = modify(ctx.object, blueprint_class, view, ctx.options)
     yield ctx
+  end
+  
+  # V1 API
+  def pre_render(object, blueprint_class, view, options)
+    modify(object, blueprint_class, view, options)
   end
 
   private

--- a/docs/v2/new/partials.md
+++ b/docs/v2/new/partials.md
@@ -37,7 +37,8 @@ class ApplicationBlueprint < Blueprinter::V2::Base
 
     # Add an inline extension to skip blank fields
     extension do
-      def around_field_value(ctx)
+      def initialize = around_field_value :skip_blank
+      def skip_blank(ctx)
         val = yield ctx
         skip! if val.blank?
         val

--- a/lib/blueprinter/errors/extension_hook.rb
+++ b/lib/blueprinter/errors/extension_hook.rb
@@ -5,8 +5,8 @@ module Blueprinter
     class ExtensionHook < StandardError
       attr_reader :message
 
-      def initialize(extension, hook, message)
-        @message = "Extension hook error in #{extension.class.name}##{hook}: #{message}"
+      def initialize(extension, hook, target, message)
+        @message = "Extension hook error in #{hook} #{extension.class.name}##{target}: #{message}"
       end
     end
   end

--- a/lib/blueprinter/extension.rb
+++ b/lib/blueprinter/extension.rb
@@ -10,19 +10,19 @@ module Blueprinter
   # V2 hooks follow a nested structure, allowing extensions to integrate deeply into the serialization lifecycle. The call
   # order of hooks looks like:
   #
-  # - [around_result](#Hook__around_result_)
-  #   - [around_blueprint_init](#Hook__around_blueprint_init_)
-  #     - [around_serialize_object](#Hook__around_serialize_object_) |
-  #       [around_serialize_collection](#Hook__around_serialize_collection_)
-  #       - [around_blueprint](#Hook__around_blueprint_)
-  #         - [around_field_value](#Hook__around_field_value_) |
-  #           [around_object_value](#Hook__around_object_value_) |
-  #           [around_collection_value](#Hook__around_collection_value_)
-  #           - [around_blueprint_init](#Hook__around_blueprint_init_)
+  # - [around_result](#around_result-instance_method)
+  #   - [around_blueprint_init](#around_blueprint_init-instance_method)
+  #     - [around_serialize_object](#around_serialize_object-instance_method) |
+  #       [around_serialize_collection](#around_serialize_collection-instance_method)
+  #       - [around_blueprint](#around_blueprint-instance_method)
+  #         - [around_field_value](#around_field_value-instance_method) |
+  #           [around_object_value](#around_object_value-instance_method) |
+  #           [around_collection_value](#around_collection_value-instance_method)
+  #           - [around_blueprint_init](#around_blueprint_init-instance_method)
   #             - …
-  # - [around_hook](#Hook__around_hook_)
+  # - [around_hook](#around_hook-instance_method)
   #
-  # === Extension hook arguments
+  # == Extension hook arguments
   #
   # Extension hooks are passed one argument: a context object. Different hooks are passed different types of context objects,
   # but they generally include things like the current Blueprint instance, the object being serialized, and the serialization
@@ -31,14 +31,14 @@ module Blueprinter
   # Some context objects can be modified by hooks, affecting the behavior of subsequent hooks or Blueprinter itself. (Think
   # Rack middleware.) See the {Blueprinter::V2::Context} module for full documentation about each type.
   #
-  # === Extension hooks yield
+  # == Extension hooks yield
   #
   # Similar to how Rack middleware calls the next middleware, Blueprinter extension hooks `yield` to the next hook,
   # ultimately yielding to Blueprinter internals.
   #
   # Some hooks require that you yield, while others allow you to skip it (e.g. a caching extension).
   #
-  # === Extensions and state
+  # == Extensions and state
   #
   # Extension instances will live for the duration of your program and may be used across threads. Generally, you should not
   # keep serialization state in your extension instance.
@@ -46,212 +46,15 @@ module Blueprinter
   # If your extension needs to store and access state specific to the current serialization, use the `ctx.state` Hash. It's
   # available to all extensions during a given `render` call.
   #
-  # === Extensions and performance
+  # == Extensions and performance
   #
   # Using extensions does incur some overhead. How much depends on which hooks you use, and of course what you do inside
   # them. Each hook below has a "Perf Impact" section that describes its expected performance impact.
   #
-  # == Hook `around_result`
-  #
-  # The outermost hook, called exactly once per render.
-  #
-  # - Argument: {Blueprinter::V2::Context::Result}
-  # - Yield: Optional
-  # - Return: Serialized result
-  # - Perf Impact: Low (run once per render)
-  #
-  # ```
-  # def around_result(ctx)
-  #   # optionally modify the context before yielding
-  #   result = yield ctx
-  #   # optionally modify the result before returning
-  #   result
-  # end
-  # ```
-  #
-  # By modifying the context, you can alter the object being serialized, the options, the serialization format, and even
-  # the Blueprint. Some extensions may wish to initialize some kind of state in `ctx.state`. And of course you can modify
-  # the result.
-  #
-  # The {Blueprinter::Extension#serialized serialized} and {Blueprinter::Extension#serialized? serialized?} helper
-  # methods can be used to declare and detect serialized values (like a JSON strings) that shouldn't be further modified.
-  #
-  # == Hook `around_blueprint_init`
-  #
-  # Called the first time each Blueprint is encountered during a serialization.
-  #
-  # - Argument: {Blueprinter::V2::Context::Init}
-  # - Yield: Required
-  # - Return: N/A
-  # - Perf Impact: Low (run once per blueprint per render)
-  #
-  # ```
-  # def around_blueprint_init(ctx)
-  #   # optionally modify the context before yielding
-  #   yield ctx
-  # end
-  # ```
-  #
-  # By modifying the context, you can sort, filter, or modify the fields that will be serialized, as well as the blueprint's
-  # options. Some extensions may wish to initialize some kind of state in `ctx.state`.
-  #
-  # == Hook `around_serialize_object`
-  #
-  # Called every time a single object is serialized. This includes an object passed to `render` as well as any singular
-  # associations defined in Blueprints.
-  #
-  # - Argument: {Blueprinter::V2::Context::Object}
-  # - Yield: Optional
-  # - Return: Serialized object as a Hash
-  # - Perf Impact: Medium (run for every object association)
-  #
-  # ```
-  # def around_serialize_object(ctx)
-  #   # optionally modify the context before yielding
-  #   result = yield ctx
-  #   # optionally modify the result before returning
-  #   result
-  # end
-  # ```
-  #
-  # By modifying the context, you can alter or replace the object about to be serialized. And of course you can modify
-  # the result.
-  #
-  # == Hook `around_serialize_collection`
-  #
-  # Called every time a collection of objects is serialized. This includes collections passed to `render` as well as any
-  # collection associations defined in Blueprints.
-  #
-  # - Argument: {Blueprinter::V2::Context::Object}
-  # - Yield: Optional
-  # - Return: Serialized collection as an Enumerable of hashes
-  # - Perf Impact: Medium (run for every collection association)
-  #
-  # ```
-  # def around_serialize_collection(ctx)
-  #   # optionally modify the context before yielding
-  #   result = yield ctx
-  #   # optionally modify the result before returning
-  #   result
-  # end
-  # ```
-  #
-  # By modifying the context, you can alter or replace the collection about to be serialized. And of course you can modify
-  # the result.
-  #
-  # == Hook `around_blueprint`
-  #
-  # Called every time a Blueprint serializes an object. For a single object it's equivalent to `around_serialize_object`.
-  # For collections it's called once per object in the collection.
-  #
-  # - Argument: {Blueprinter::V2::Context::Object}
-  # - Yield: Optional
-  # - Return: Serialized object as a Hash
-  # - Perf Impact: Medium (run for every object association, N times for every collection association)
-  #
-  # ```
-  # def around_blueprint(ctx)
-  #   # optionally modify the context before yielding
-  #   result = yield ctx
-  #   # optionally modify the result before returning
-  #   result
-  # end
-  # ```
-  #
-  # By modifying the context, you can alter or replace the object about to be serialized. And of course you can modify
-  # the result.
-  #
-  # == Hook `around_field_value`
-  #
-  # Called for every non-object, non-collection field defined in the Blueprint. (Skipped if a field fails its if/unless
-  # checks.)
-  #
-  # - Argument: {Blueprinter::V2::Context::Field}
-  # - Yield: Optional
-  # - Return: The extracted field value
-  # - Perf Impact: High (run for every regular field)
-  #
-  # ```
-  # def around_field_value(ctx)
-  #   # optionally modify the context before yielding
-  #   result = yield ctx
-  #   # optionally modify the result before returning
-  #   result
-  # end
-  # ```
-  #
-  # NOTE: Any {Blueprinter::V2::DSL::Data#format formatters} are called after all `around_field_value` hooks.
-  #
-  # The {Blueprinter::Extension#skip! skip!} helper may be used to abort field hooks and omit a field from the result.
-  #
-  # If you want to handle field extraction on your own, omit the `yield` and extract the value yourself using
-  # {Blueprinter::V2::Context::Field#field ctx.field} and {Blueprinter::V2::Context::Field#object ctx.object}.
-  #
-  # == Hook `around_object_value`
-  #
-  # Called for every object field defined in the Blueprint. (Skipped if a field fails its if/unless checks.)
-  #
-  # - Argument: {Blueprinter::V2::Context::Field}
-  # - Yield: Optional
-  # - Return: The extracted object (unserialized)
-  # - Perf Impact: High (run for every object field)
-  #
-  # ```
-  # def around_object_value(ctx)
-  #   # optionally modify the context before yielding
-  #   result = yield ctx
-  #   # optionally modify the result before returning
-  #   result
-  # end
-  # ```
-  #
-  # The {Blueprinter::Extension#skip! skip!} helper may be used to abort field hooks and omit a field from the result.
-  #
-  # If you want to handle object extraction on your own, omit the `yield` and extract the value yourself using
-  # {Blueprinter::V2::Context::Field#field ctx.field} and {Blueprinter::V2::Context::Field#object ctx.object}.
-  #
-  # == Hook `around_collection_value`
-  #
-  # Called for every collection field defined in the Blueprint. (Skipped if a field fails its if/unless checks.)
-  #
-  # - Argument: {Blueprinter::V2::Context::Field}
-  # - Yield: Optional
-  # - Return: The extracted collection (unserialized)
-  # - Perf Impact: High (run for every collection field)
-  #
-  # ```
-  # def around_collection_value(ctx)
-  #   # optionally modify the context before yielding
-  #   result = yield ctx
-  #   # optionally modify the result before returning
-  #   result
-  # end
-  # ```
-  #
-  # The {Blueprinter::Extension#skip! skip!} helper may be used to abort field hooks and omit a field from the result.
-  #
-  # If you want to handle collection extraction on your own, omit the `yield` and extract the value yourself using
-  # {Blueprinter::V2::Context::Field#field ctx.field} and {Blueprinter::V2::Context::Field#object ctx.object}.
-  #
-  # == Hook `around_hook`
-  #
-  # A meta hook that runs around all other extension hooks. It can't affect the serialized output and is most
-  # useful for instrumentation and logging. The included {Blueprinter::Extensions::OpenTelemetry} extension
-  # uses it to trace other extensions.
-  #
-  # - Argument: {Blueprinter::V2::Context::Hook}
-  # - Yield: Required (no context)
-  # - Return: N/A
-  # - Perf Impact: Depends heavily on which extension hooks are in use and how many. Field-level hooks will have
-  # a greater performance impact than others.
-  #
-  # ```
-  # def around_hook(ctx)
-  #   my_instrumentation ctx do
-  #     yield
-  #   end
-  # end
-  # ```
+  # Many behavious can be implemented differently using different hooks. Which hook you choose can impact performance. Read
+  # the
+  # [Performance](https://procore-oss.github.io/blueprinter/extensions/performance.html) section of the V2 Extension Guide
+  # for some examples.
   #
   # = V1 Hooks
   #
@@ -277,6 +80,9 @@ module Blueprinter
   #
   class Extension
     # @!visibility private
+    Hook = Struct.new(:name, :ext, :target)
+
+    # @!visibility private
     HOOKS = %i[
       around_hook
       around_result
@@ -289,12 +95,6 @@ module Blueprinter
       around_collection_value
       pre_render
     ].freeze
-
-    # @return [Array<Symbol>] The names of the hooks implemented in this extension
-    # @!visibility private
-    def self.hooks
-      @_hooks ||= (public_instance_methods(true) & HOOKS).freeze
-    end
 
     # If this returns true, `around_hook` will not be called when this extension's hooks are run.
     #
@@ -349,5 +149,263 @@ module Blueprinter
     # @param val [Object] The value in question
     # @return [true | false]
     def serialized?(val) = val.is_a? V2::Context::Serialized
+
+    # Freezes hooks and returns registered hooks
+    # @!visibility private
+    def finalize_hooks = _hooks.freeze
+
+    private
+
+    # Registers an `around_result` hook. `around_result` is the outermost hook, called exactly once on the Blueprint that's
+    # being rendered.
+    #
+    # - Argument: {Blueprinter::V2::Context::Result}
+    # - Yield: Optional
+    # - Return: Serialized result
+    # - Perf Impact: Low (run once per render)
+    #
+    # ```
+    # def initialize = around_result :my_result_hook
+    #
+    # def my_result_hook(ctx)
+    #   # optionally modify the context before yielding
+    #   result = yield ctx
+    #   # optionally modify the result before returning
+    #   result
+    # end
+    # ```
+    #
+    # By modifying the context, you can alter the object being serialized, the options, the serialization format, and even
+    # the Blueprint. Some extensions may wish to initialize some kind of state in `ctx.state`. And of course you can modify
+    # the result.
+    #
+    # The {Blueprinter::Extension#serialized serialized} and {Blueprinter::Extension#serialized? serialized?} helper
+    # methods can be used to declare and detect serialized values (like a JSON strings) that shouldn't be further modified.
+    #
+    # @param name [Symbol] Name of instance method that implements hook
+    # @!visibility public
+    def around_result(name) = register_hook(:around_result, name)
+
+    # Registers an `around_blueprint_init` hook. Called the first time each Blueprint is encountered during a serialization.
+    #
+    # - Argument: {Blueprinter::V2::Context::Init}
+    # - Yield: Required
+    # - Return: N/A
+    # - Perf Impact: Low (run once per blueprint per render)
+    #
+    # ```
+    # def initialize = around_blueprint_init :my_init_hook
+    #
+    # def my_init_hook(ctx)
+    #   # optionally modify the context before yielding
+    #   yield ctx
+    # end
+    # ```
+    #
+    # By modifying the context, you can sort, filter, or modify the fields that will be serialized, as well as the
+    # blueprint's options. Some extensions may wish to initialize some kind of state in `ctx.state`.
+    #
+    # @param name [Symbol] Name of instance method that implements hook
+    # @!visibility public
+    def around_blueprint_init(name) = register_hook(:around_blueprint_init, name)
+
+    # Registers an `around_serialize_object` hook. Called every time a single object is serialized. This includes an object
+    # passed to `render` as well as any singular associations defined in Blueprints.
+    #
+    # - Argument: {Blueprinter::V2::Context::Object}
+    # - Yield: Optional
+    # - Return: Serialized object as a Hash
+    # - Perf Impact: Medium (run for every object association)
+    #
+    # ```
+    # def initialize = around_serialize_object :my_serialize_hook
+    #
+    # def my_serialize_hook(ctx)
+    #   # optionally modify the context before yielding
+    #   result = yield ctx
+    #   # optionally modify the result before returning
+    #   result
+    # end
+    # ```
+    #
+    # By modifying the context, you can alter or replace the object about to be serialized. And of course you can modify
+    # the result.
+    #
+    # @param name [Symbol] Name of instance method that implements hook
+    # @!visibility public
+    def around_serialize_object(name) = register_hook(:around_serialize_object, name)
+
+    # Registers an `around_serialize_collection` hook. Called every time a collection of objects is serialized. This includes
+    # collections passed to `render` as well as any collection associations defined in Blueprints.
+    #
+    # - Argument: {Blueprinter::V2::Context::Object}
+    # - Yield: Optional
+    # - Return: Serialized collection as an Enumerable of hashes
+    # - Perf Impact: Medium (run for every collection association)
+    #
+    # ```
+    # def initialize = around_serialize_collection :my_serialize_hook
+    #
+    # def my_serialize_hook(ctx)
+    #   # optionally modify the context before yielding
+    #   result = yield ctx
+    #   # optionally modify the result before returning
+    #   result
+    # end
+    # ```
+    #
+    # By modifying the context, you can alter or replace the collection about to be serialized. And of course you can modify
+    # the result.
+    #
+    # @param name [Symbol] Name of instance method that implements hook
+    # @!visibility public
+    def around_serialize_collection(name) = register_hook(:around_serialize_collection, name)
+
+    # Registers an `around_blueprint` hook. Called every time a Blueprint serializes an object. For a single object it's
+    # equivalent to `around_serialize_object`. For collections it's called once per object in the collection.
+    #
+    # - Argument: {Blueprinter::V2::Context::Object}
+    # - Yield: Optional
+    # - Return: Serialized object as a Hash
+    # - Perf Impact: Medium (run for every object association, N times for every collection association)
+    #
+    # ```
+    # def initialize = around_blueprint :my_blueprint_hook
+    #
+    # def my_blueprint_hook(ctx)
+    #   # optionally modify the context before yielding
+    #   result = yield ctx
+    #   # optionally modify the result before returning
+    #   result
+    # end
+    # ```
+    #
+    # By modifying the context, you can alter or replace the object about to be serialized. And of course you can modify
+    # the result.
+    #
+    # @param name [Symbol] Name of instance method that implements hook
+    # @!visibility public
+    def around_blueprint(name) = register_hook(:around_blueprint, name)
+
+    # Registers an `around_field_value` hook. Called for every non-object, non-collection field defined in the Blueprint.
+    # (Skipped if a field fails its if/unless checks.)
+    #
+    # - Argument: {Blueprinter::V2::Context::Field}
+    # - Yield: Optional
+    # - Return: The extracted field value
+    # - Perf Impact: High (run for every regular field)
+    #
+    # ```
+    # def initialize = around_field_value :my_field_hook
+    #
+    # def my_field_hook(ctx)
+    #   # optionally modify the context before yielding
+    #   result = yield ctx
+    #   # optionally modify the result before returning
+    #   result
+    # end
+    # ```
+    #
+    # NOTE: Any {Blueprinter::V2::DSL::Data#format formatters} are called after all `around_field_value` hooks.
+    #
+    # The {Blueprinter::Extension#skip! skip!} helper may be used to abort field hooks and omit a field from the result.
+    #
+    # If you want to handle field extraction on your own, omit the `yield` and extract the value yourself using
+    # {Blueprinter::V2::Context::Field#field ctx.field} and {Blueprinter::V2::Context::Field#object ctx.object}.
+    #
+    # @param name [Symbol] Name of instance method that implements hook
+    # @!visibility public
+    def around_field_value(name) = register_hook(:around_field_value, name)
+
+    # Registers an `around_object_value` hook. Called for every object field defined in the Blueprint. (Skipped if a field
+    # fails its if/unless checks.)
+    #
+    # - Argument: {Blueprinter::V2::Context::Field}
+    # - Yield: Optional
+    # - Return: The extracted object (unserialized)
+    # - Perf Impact: High (run for every object field)
+    #
+    # ```
+    # def initialize = around_object_value :my_object_hook
+    #
+    # def my_object_hook(ctx)
+    #   # optionally modify the context before yielding
+    #   result = yield ctx
+    #   # optionally modify the result before returning
+    #   result
+    # end
+    # ```
+    #
+    # The {Blueprinter::Extension#skip! skip!} helper may be used to abort field hooks and omit a field from the result.
+    #
+    # If you want to handle object extraction on your own, omit the `yield` and extract the value yourself using
+    # {Blueprinter::V2::Context::Field#field ctx.field} and {Blueprinter::V2::Context::Field#object ctx.object}.
+    #
+    # @param name [Symbol] Name of instance method that implements hook
+    # @!visibility public
+    def around_object_value(name) = register_hook(:around_object_value, name)
+
+    # Registers an `around_collection_value` hook. Called for every collection field defined in the Blueprint. (Skipped if a
+    # field fails its if/unless checks.)
+    #
+    # - Argument: {Blueprinter::V2::Context::Field}
+    # - Yield: Optional
+    # - Return: The extracted collection (unserialized)
+    # - Perf Impact: High (run for every collection field)
+    #
+    # ```
+    # def initialize = around_collection_value :my_collection_hook
+    #
+    # def my_collection_hook(ctx)
+    #   # optionally modify the context before yielding
+    #   result = yield ctx
+    #   # optionally modify the result before returning
+    #   result
+    # end
+    # ```
+    #
+    # The {Blueprinter::Extension#skip! skip!} helper may be used to abort field hooks and omit a field from the result.
+    #
+    # If you want to handle collection extraction on your own, omit the `yield` and extract the value yourself using
+    # {Blueprinter::V2::Context::Field#field ctx.field} and {Blueprinter::V2::Context::Field#object ctx.object}.
+    #
+    # @param name [Symbol] Name of instance method that implements hook
+    # @!visibility public
+    def around_collection_value(name) = register_hook(:around_collection_value, name)
+
+    # Registers an `around_hook` hook. A meta hook that runs around all other extension hooks.
+    #
+    # It can't affect the serialized output and is most useful for instrumentation and logging. The included
+    # {Blueprinter::Extensions::OpenTelemetry} extension uses it to trace other extensions.
+    #
+    # - Argument: {Blueprinter::V2::Context::Hook}
+    # - Yield: Required (no context)
+    # - Return: N/A
+    # - Perf Impact: Depends heavily on which extension hooks are in use and how many. Field-level hooks will have
+    # a greater performance impact than others.
+    #
+    # ```
+    # def initialize = around_hook :my_instrumentation_hook
+    #
+    # def my_instrumentation_hook(ctx)
+    #   my_instrumentation ctx do
+    #     yield
+    #   end
+    # end
+    # ```
+    #
+    # @param name [Symbol] Name of instance method that implements hook
+    # @!visibility public
+    def around_hook(name) = register_hook(:around_hook, name)
+
+    def register_hook(hook_name, method_name)
+      raise ArgumentError, "Invalid hook name: #{hook_name.inspect}" unless HOOKS.include? hook_name
+      raise ArgumentError, "Invalid call name: #{method_name.inspect}" unless respond_to? method_name
+
+      _hooks << Hook.new(hook_name, self, method_name).freeze
+      _hooks.uniq!
+    end
+
+    def _hooks = @_hooks ||= []
   end
 end

--- a/lib/blueprinter/extensions.rb
+++ b/lib/blueprinter/extensions.rb
@@ -18,6 +18,7 @@ module Blueprinter
   # == V1 Compatibility Extensions
   #
   # - {Blueprinter::Extensions::LegacyOptions} Enables some V1-compatible options
+  # - {Blueprinter::Extensions::LegacyDynamicOptions} Enables V1-compatible dynamic options on associations
   # - {Blueprinter::Extensions::LegacyTransformer} Add V1-compatible transformers
   #
   # == Community extensions

--- a/lib/blueprinter/extensions/field_order.rb
+++ b/lib/blueprinter/extensions/field_order.rb
@@ -22,11 +22,12 @@ module Blueprinter
       #        return -1, 0, or 1
       def initialize(&sorter)
         @sorter = sorter
+        around_blueprint_init :sort_fields
       end
 
       # @param ctx [Blueprinter::V2::Context::Init]
       # @!visibility private
-      def around_blueprint_init(ctx)
+      def sort_fields(ctx)
         ctx.fields = ctx.fields.sort(&@sorter)
         yield ctx
       end

--- a/lib/blueprinter/extensions/legacy_dynamic_options.rb
+++ b/lib/blueprinter/extensions/legacy_dynamic_options.rb
@@ -5,7 +5,8 @@ module Blueprinter
     #
     # Support for Legacy/V1's `:options` option on associations.
     #
-    # Add the extension to the Blueprint (or view) that needs dynamic options:
+    # For optimal performance it's recommended to add this extension only to Blueprints/views that use dynamic options,
+    # rather than to `ApplicationBlueprint`.
     #
     # ```
     # class WidgetBlueprint < ApplicationBlueprint
@@ -26,6 +27,13 @@ module Blueprinter
     #
     class LegacyDynamicOptions < Extension
       # @!visibility private
+      def initialize
+        around_serialize_object :apply
+        around_serialize_collection :apply
+      end
+
+      # @param ctx [Blueprinter::V2::Context::Object]
+      # @!visibility private
       def apply(ctx)
         ctx.fields.each do |field|
           additional_opts =
@@ -37,12 +45,6 @@ module Blueprinter
         end
         yield ctx
       end
-
-      # @!visibility private
-      alias around_serialize_object apply
-
-      # @!visibility private
-      alias around_serialize_collection apply
     end
   end
 end

--- a/lib/blueprinter/extensions/legacy_options.rb
+++ b/lib/blueprinter/extensions/legacy_options.rb
@@ -86,34 +86,26 @@ module Blueprinter
       # @!visibility private
       V1_COND_ARITY = 3
 
-      # @param ctx [Blueprinter::V2::Context::Result]
-      # @!visibility private
-      def around_result(ctx)
-        apply_render_view_option ctx
-        yield ctx
+      def initialize
+        around_result :apply_render_view_option
+        around_blueprint_init :init_legacy_conditionals
+        around_blueprint_init :init_legacy_default_ifs
+        around_blueprint_init :init_legacy_field_names
+        around_blueprint_init :init_legacy_extractors
       end
 
-      # @param ctx [Blueprinter::V2::Context::Init]
-      # @!visibility private
-      def around_blueprint_init(ctx)
-        init_legacy_conditionals ctx
-        init_legacy_default_ifs ctx
-        init_legacy_field_names ctx
-        init_legacy_extractors ctx
-        yield ctx
-      end
-
-      private
-
       # @param ctx [Blueprinter::V2::Context::Result]
+      # @!visibility private
       def apply_render_view_option(ctx)
         if (view = ctx.options[:view])
           ctx.blueprint = ctx.blueprint.class[view].new
           ctx.options = ctx.options.except(:view).freeze
         end
+        yield ctx
       end
 
       # @param ctx [Blueprinter::V2::Context::Init]
+      # @!visibility private
       def init_legacy_conditionals(ctx)
         # Convert blueprint if/unless options
         ctx.blueprint.options[:if] = wrap_v1_cond(ctx.blueprint.options[:if]) if ctx.blueprint.options[:if]
@@ -124,9 +116,11 @@ module Blueprinter
           field.options[:if] = wrap_v1_cond(field.options[:if]) if field.options[:if]
           field.options[:unless] = wrap_v1_cond(field.options[:unless]) if field.options[:unless]
         end
+        yield ctx
       end
 
       # @param ctx [Blueprinter::V2::Context::Init]
+      # @!visibility private
       def init_legacy_default_ifs(ctx)
         # Convert blueprint default_if option
         if (default_if = ctx.blueprint.options[:default_if])
@@ -139,9 +133,11 @@ module Blueprinter
             field.options[:default_if] = wrap_v1_default_if(default_if)
           end
         end
+        yield ctx
       end
 
       # @param ctx [Blueprinter::V2::Context::Init]
+      # @!visibility private
       def init_legacy_field_names(ctx)
         ctx.fields.each do |field|
           if (name = field.options[:name])
@@ -149,9 +145,11 @@ module Blueprinter
             field.name = name
           end
         end
+        yield ctx
       end
 
       # @param ctx [Blueprinter::V2::Context::Init]
+      # @!visibility private
       def init_legacy_extractors(ctx)
         default_extractor = ctx.blueprint.options[:extractor]
         ctx.fields.each do |field|
@@ -162,7 +160,10 @@ module Blueprinter
             extractor_class.new.extract(field.source, ctx.object, ctx.options, field.options)
           end
         end
+        yield ctx
       end
+
+      private
 
       def wrap_v1_cond(cond)
         if cond.is_a?(Proc) && cond.arity == V1_COND_ARITY

--- a/lib/blueprinter/extensions/legacy_options.rb
+++ b/lib/blueprinter/extensions/legacy_options.rb
@@ -157,7 +157,7 @@ module Blueprinter
           next if extractor_class.nil?
 
           field.block = proc do |_obj, ctx|
-            extractor_class.new.extract(field.source, ctx.object, ctx.options, field.options)
+            extractor_class.new.extract(ctx.field.source, ctx.object, ctx.options, ctx.field.options)
           end
         end
         yield ctx

--- a/lib/blueprinter/extensions/legacy_transformer.rb
+++ b/lib/blueprinter/extensions/legacy_transformer.rb
@@ -17,11 +17,12 @@ module Blueprinter
       # @param transformers [Class] One or more transformers (Blueprinter::Transformer)
       def initialize(*transformers)
         @transformers = transformers
+        around_blueprint :transform
       end
 
       # @param ctx [Blueprinter::V2::Context::Object]
       # @!visibility private
-      def around_blueprint(ctx)
+      def transform(ctx)
         hash = yield ctx
         @transformers.each do |klass|
           transformer = ctx.store[klass.object_id] ||= klass.new

--- a/lib/blueprinter/extensions/multi_json.rb
+++ b/lib/blueprinter/extensions/multi_json.rb
@@ -27,11 +27,12 @@ module Blueprinter
       # @param options [Hash] Any options you pass here will be passed through to `MultiJson.dump`
       def initialize(options = {})
         @options = options
+        around_result :serialize
       end
 
       # @param ctx [Blueprinter::V2::Context::Result]
       # @!visibility private
-      def around_result(ctx)
+      def serialize(ctx)
         result = yield ctx
         return result unless ctx.format == :json
 

--- a/lib/blueprinter/extensions/open_telemetry.rb
+++ b/lib/blueprinter/extensions/open_telemetry.rb
@@ -27,13 +27,17 @@ module Blueprinter
       # Initialize the extension with the tracer's name.
       #
       # @param tracer_name [String]
-      def initialize(tracer_name)
+      # @param trace_extensions [Boolean] Trace hooks registered by extensions (adds overhead)
+      def initialize(tracer_name, trace_extensions: true)
         @tracer_name = tracer_name
+        around_serialize_object :trace_object
+        around_serialize_collection :trace_collection
+        around_hook :trace_hook if trace_extensions
       end
 
       # @param ctx [Blueprinter::V2::Context::Object]
       # @!visibility private
-      def around_serialize_object(ctx)
+      def trace_object(ctx)
         tracer.in_span('blueprinter.object', attributes: attributes(ctx)) do
           yield ctx
         end
@@ -41,7 +45,7 @@ module Blueprinter
 
       # @param ctx [Blueprinter::V2::Context::Object]
       # @!visibility private
-      def around_serialize_collection(ctx)
+      def trace_collection(ctx)
         tracer.in_span('blueprinter.collection', attributes: attributes(ctx)) do
           yield ctx
         end
@@ -49,9 +53,10 @@ module Blueprinter
 
       # @param ctx [Blueprinter::V2::Context::Hook]
       # @!visibility private
-      def around_hook(ctx)
+      def trace_hook(ctx)
         extension = ctx.extension.class.name
-        attributes = { extension:, hook: ctx.hook, 'library.name' => 'Blueprinter', 'library.version' => VERSION }
+        attributes = { extension:, method: ctx.target, hook: ctx.hook, 'library.name' => 'Blueprinter',
+                       'library.version' => VERSION }
         tracer.in_span('blueprinter.extension', attributes:) { |_| yield }
       end
 

--- a/lib/blueprinter/hooks.rb
+++ b/lib/blueprinter/hooks.rb
@@ -8,9 +8,12 @@ module Blueprinter
     def initialize(extensions)
       @hooks = Extension::HOOKS.to_h { |hook| [hook, []] }
       extensions.each do |ext|
-        ext.class.hooks.each { |hook| @hooks[hook] << ext }
+        ext.finalize_hooks.each { |hook| @hooks[hook.name] << hook }
+        # V1 doesn't have to register its hooks
+        @hooks[:pre_render] << Extension::Hook.new(:pre_render, ext, :pre_render).freeze if ext.respond_to?(:pre_render)
       end
       @hooks.freeze
+      @hooks.each(&:freeze)
       @hook_around_hook = registered? :around_hook
       @around_hooks = @hooks[:around_hook]
     end
@@ -42,66 +45,68 @@ module Blueprinter
     def around(hook, ctx, require_yield: false, &)
       hooks = @hooks.fetch(hook)
       if !@hook_around_hook && !require_yield
-        _around_direct(hooks, hook, 0, ctx, ctx.class, &)
+        _around_direct(hooks, 0, ctx, ctx.class, &)
       else
-        _around(hooks, hook, 0, ctx, ctx.class, require_yield:, &)
+        _around(hooks, 0, ctx, ctx.class, require_yield:, &)
       end
     end
 
     private
 
     # Fast path: no around_hook wrapping, no require_yield
-    def _around_direct(hooks, hook, idx, ctx, klass, &)
-      ext = hooks[idx]
-      return yield ctx if ext.nil?
+    def _around_direct(hooks, idx, ctx, klass, &)
+      hook = hooks[idx]
+      return yield ctx if hook.nil?
 
-      ext.public_send(hook, ctx) do |yctx|
+      hook.ext.public_send(hook.target, ctx) do |yctx|
         unless yctx.is_a?(klass)
-          raise Errors::ExtensionHook.new(ext, hook, "should yield `#{klass.name}` but yielded `#{yctx.inspect}`")
+          msg = "should yield `#{klass.name}` but yielded `#{yctx.inspect}`"
+          raise Errors::ExtensionHook.new(hook.ext, hook.name, hook.target, msg)
         end
 
-        _around_direct(hooks, hook, idx + 1, yctx || ctx, klass, &)
+        _around_direct(hooks, idx + 1, yctx || ctx, klass, &)
       end
     end
 
     # Runs hooks recursively
-    def _around(hooks, hook, idx, ctx, expected_yield, require_yield: false, &)
-      ext = hooks[idx]
-      return yield ctx if ext.nil?
+    def _around(hooks, idx, ctx, expected_yield, require_yield: false, &)
+      hook = hooks[idx]
+      return yield ctx if hook.nil?
 
       yielded = false
-      result = call(ext, hook, ctx) do |yielded_ctx|
+      result = call(hook, ctx) do |yielded_ctx|
         yielded ||= true
         unless yielded_ctx.is_a? expected_yield
           msg = "should yield `#{expected_yield.name}` but yielded `#{yielded_ctx.inspect}`"
-          raise Errors::ExtensionHook.new(ext, hook, msg)
+          raise Errors::ExtensionHook.new(hook.ext, hook.name, hook.target, msg)
         end
 
         ctx = yielded_ctx if yielded_ctx
-        _around(hooks, hook, idx + 1, ctx, expected_yield, require_yield:, &)
+        _around(hooks, idx + 1, ctx, expected_yield, require_yield:, &)
       end
-      raise Errors::ExtensionHook.new(ext, hook, 'did not yield') if require_yield && !yielded
+      raise Errors::ExtensionHook.new(hook.ext, hook.name, hook.target, 'did not yield') if require_yield && !yielded
 
       result
     end
 
     # Calls a hook on an extension. If the `around_hook` hook is registered it's wrapped around the call.
-    def call(ext, hook, ctx, &)
-      return ext.public_send(hook, ctx, &) if !@hook_around_hook || ext.hidden? || hook == :around_hook
+    def call(hook, ctx, &)
+      return hook.ext.public_send(hook.target, ctx, &) if !@hook_around_hook || hook.ext.hidden? || hook.name == :around_hook
 
       # Hacky, but re-using this context object saves tons of time
       hook_ctx = Thread.current[:_blueprinter_hook_ctx] ||= V2::Context::Hook.new
       hook_ctx.blueprint = ctx.blueprint
       hook_ctx.fields = ctx.fields
       hook_ctx.options = ctx.options
-      hook_ctx.extension = ext
-      hook_ctx.hook = hook
+      hook_ctx.extension = hook.ext
+      hook_ctx.target = hook.target
+      hook_ctx.hook = hook.name
       hook_ctx.store = ctx.store
       hook_ctx.depth = ctx.depth
       result = nil
-      _around(@around_hooks, :around_hook, 0, hook_ctx, NilClass, require_yield: true) do
+      _around(@around_hooks, 0, hook_ctx, NilClass, require_yield: true) do
         # return the inner hook's value, not around_hook's
-        result = ext.public_send(hook, ctx, &)
+        result = hook.ext.public_send(hook.target, ctx, &)
       end
       result
     end

--- a/lib/blueprinter/rendering.rb
+++ b/lib/blueprinter/rendering.rb
@@ -95,8 +95,8 @@ module Blueprinter
       raise BlueprinterError, "View '#{view_name}' is not defined" unless view_collection.view?(view_name)
 
       hooks = Blueprinter.configuration.hooks[:pre_render]
-      object = hooks.reduce(object) do |val, ext|
-        ext.pre_render(val, self, view_name, local_options)
+      object = hooks.reduce(object) do |val, hook|
+        hook.ext.pre_render(val, self, view_name, local_options)
       end
 
       prepare_data(object, view_name, local_options)

--- a/lib/blueprinter/v2/context.rb
+++ b/lib/blueprinter/v2/context.rb
@@ -31,13 +31,15 @@ module Blueprinter
       # @!attribute [r] blueprint
       #   @return [Blueprinter::V2::Base] Instance of the outer Blueprint class
       # @!attribute [r] fields
-      #   @return [Array<Blueprinter::V2::Fields::Field>]
+      #   @return [Array<Blueprinter::V2::Fields::Field>] All fields that will be serialized
       # @!attribute [r] options
       #   @return [Hash] Options passed to `render` (frozen)
       # @!attribute [r] extension
       #   @return [Blueprinter::Extension] Instance of the extension running
       # @!attribute [r] hook
-      #   @return [Symbol] Name of the symbol being called
+      #   @return [Symbol] Name of the hook being called
+      # @!attribute [r] target
+      #   @return [Symbol] Name of the extension method being called
       # @!attribute [r] depth
       #   @return [Integer] Blueprint depth (1-indexed)
       # @!attribute [r] store
@@ -45,7 +47,7 @@ module Blueprinter
       # @!attribute [r] depth
       #   @return [Integer] Current serialization depth
       #
-      Hook = Struct.new(:blueprint, :fields, :options, :extension, :hook, :store, :depth)
+      Hook = Struct.new(:blueprint, :fields, :options, :extension, :hook, :target, :store, :depth)
 
       #
       # The object or collection currently being serialized.
@@ -53,7 +55,7 @@ module Blueprinter
       # @!attribute [r] blueprint
       #   @return [Blueprinter::V2::Base] Instance of the current Blueprint class
       # @!attribute [r] fields
-      #   @return [Array<Blueprinter::V2::Fields::Field>]
+      #   @return [Array<Blueprinter::V2::Fields::Field>] All fields that will be serialized
       # @!attribute [rw] options
       #   @return [Hash] Options passed to `render` (frozen but can be replaced)
       # @!attribute [rw] object
@@ -95,7 +97,7 @@ module Blueprinter
       # @!attribute [r] blueprint
       #   @return [Blueprinter::V2::Base] Instance of the current Blueprint class
       # @!attribute [r] fields
-      #   @return [Array<Blueprinter::V2::Fields::Field>]
+      #   @return [Array<Blueprinter::V2::Fields::Field>] All fields that will be serialized
       # @!attribute [r] options
       #   @return [Hash] Options passed to `render` (frozen)
       # @!attribute [r] object
@@ -121,7 +123,7 @@ module Blueprinter
       #   @return [Blueprinter::V2::Base] Instance of the current Blueprint class. If replaced, the render is aborted and a
       #           new one begun.
       # @!attribute [r] fields
-      #   @return [Array<Blueprinter::V2::Fields::Field>]
+      #   @return [Array<Blueprinter::V2::Fields::Field>] All fields that were serialized
       # @!attribute [rw] options
       #   @return [Hash] Options passed to `render`. Can be modified.
       # @!attribute [rw] object

--- a/lib/blueprinter/v2/dsl/config.rb
+++ b/lib/blueprinter/v2/dsl/config.rb
@@ -105,8 +105,10 @@ module Blueprinter
         # ```
         # class WidgetBlueprint < ApplicationBlueprint
         #   extension do
+        #     def initialize = around_blueprint :decorate
+        #
         #     # Decorate Blueprint output
-        #     def around_blueprint(ctx)
+        #     def decorate(ctx)
         #       hash = yield ctx
         #       hash[:meta] = metadata ctx.object
         #       hash

--- a/lib/blueprinter/v2/extensions/core/format.rb
+++ b/lib/blueprinter/v2/extensions/core/format.rb
@@ -11,8 +11,12 @@ module Blueprinter
         # @!visibility private
         #
         class Format < Extension
+          def initialize
+            around_result :format
+          end
+
           # @param ctx [Blueprinter::V2::Context::Result]
-          def around_result(ctx)
+          def format(ctx)
             result = yield ctx
             return result if serialized? result
 

--- a/lib/blueprinter/v2/extensions/core/root.rb
+++ b/lib/blueprinter/v2/extensions/core/root.rb
@@ -9,8 +9,12 @@ module Blueprinter
         # @!visibility private
         #
         class Root < Extension
+          def initialize
+            around_result :wrap_root
+          end
+
           # @param ctx [Blueprinter::V2::Context::Result]
-          def around_result(ctx)
+          def wrap_root(ctx)
             result = yield ctx
             root_name = ctx.options[:root]
             return result if serialized?(result) || !root_name

--- a/spec/extensions/hooks_spec.rb
+++ b/spec/extensions/hooks_spec.rb
@@ -18,16 +18,18 @@ describe Blueprinter::Hooks do
     Class.new(Blueprinter::Extension) do
       attr_reader :log
 
-      def initialize = @log = []
+      def initialize
+        @log = []
+        around_blueprint_init :init
+        around_serialize_object :serialize
+      end
 
-      def blueprint_setup(_context) = log << 'blueprint_setup'
-
-      def around_blueprint_init(ctx)
+      def init(ctx)
         ctx.fields = ctx.blueprint.class.reflections[:default].ordered
         yield ctx
       end
 
-      def around_serialize_object(context)
+      def serialize(context)
         res = yield context
         res[:n] += 1 if res[:n]
         res
@@ -38,9 +40,12 @@ describe Blueprinter::Hooks do
     Class.new(Blueprinter::Extension) do
       attr_reader :log
 
-      def initialize = @log = []
+      def initialize
+        @log = []
+        around_blueprint_init :init
+      end
 
-      def around_blueprint_init(ctx)
+      def init(ctx)
         log << 'around_blueprint_init'
         ctx.fields = ctx.blueprint.class.reflections[:default].ordered.reverse
         yield ctx
@@ -62,9 +67,10 @@ describe Blueprinter::Hooks do
       Class.new(Blueprinter::Extension) do
         def initialize(log)
           @log = log
+          around_serialize_object :serialize
         end
 
-        def around_serialize_object(ctx)
+        def serialize(ctx)
           @log << "A: #{ctx.object[:n]}"
           ctx.object = { n: ctx.object[:n] + 1 }
           res = yield ctx
@@ -76,7 +82,12 @@ describe Blueprinter::Hooks do
 
     let(:ext_b) do
       Class.new(ext_a) do
-        def around_serialize_object(ctx)
+        def initialize(*args)
+          super
+          around_serialize_object :serialize
+        end
+
+        def serialize(ctx)
           @log << "B: #{ctx.object[:n]}"
           ctx.object = { n: ctx.object[:n] + 1 }
           res = yield ctx
@@ -88,7 +99,12 @@ describe Blueprinter::Hooks do
 
     let(:ext_c) do
       Class.new(ext_a) do
-        def around_serialize_object(ctx)
+        def initialize(*args)
+          super
+          around_serialize_object :serialize
+        end
+
+        def serialize(ctx)
           @log << "C: #{ctx.object[:n]}"
           ctx.object = { n: ctx.object[:n] + 1 }
           res = yield ctx
@@ -100,7 +116,12 @@ describe Blueprinter::Hooks do
 
     let(:cache_ext) do
       Class.new(ext_a) do
-        def around_serialize_object(ctx)
+        def initialize(*args)
+          super
+          around_serialize_object :serialize
+        end
+
+        def serialize(ctx)
           @log << "Cache: #{ctx.object[:n]}"
           res =  { n: 42 }
           @log << "Cache END"
@@ -151,7 +172,8 @@ describe Blueprinter::Hooks do
     it 'bypasses parent hooks with a skip in a nested hook' do
       log = []
       ext = Class.new(Blueprinter::Extension) do
-        def around_serialize_object(_ctx) = skip!
+        def initialize = around_serialize_object :serialize
+        def serialize(_ctx) = skip!
       end
       extensions = [ext_a.new(log), ext_b.new(log), ext.new, ext_c.new(log)]
       ctx = object_ctx.new(blueprint.new, serializer.default_fields, {}, { n: 0 })
@@ -182,7 +204,8 @@ describe Blueprinter::Hooks do
 
     it 'requires that the yielded arg is the same class as the method arg' do
       ext = Class.new(Blueprinter::Extension) do
-        def around_serialize_object(_ctx) = yield "oops"
+        def initialize = around_serialize_object :serialize
+        def serialize(_ctx) = yield "oops"
       end
 
       ctx = object_ctx.new(blueprint.new, serializer.default_fields, {}, { n: 0 })
@@ -196,16 +219,20 @@ describe Blueprinter::Hooks do
   context '#around_hook' do
     let(:ext1) do
       Class.new(Blueprinter::Extension) do
-        def initialize(log) = @log = log
+        def initialize(log)
+          @log = log
+          around_serialize_object :serialize
+          around_hook :hook
+        end
 
-        def around_serialize_object(ctx)
+        def serialize(ctx)
           @log << 'around_serialize_object: A'
           res = yield ctx
           @log << 'around_serialize_object: B'
           res
         end
 
-        def around_hook(ctx)
+        def hook(ctx)
           @log << "around_hook(#{ctx.extension.class.name}##{ctx.hook}): A"
           yield
           @log << "around_hook(#{ctx.extension.class.name}##{ctx.hook}): B"
@@ -253,7 +280,8 @@ describe Blueprinter::Hooks do
 
     it 'must yield' do
       ext = Class.new(Blueprinter::Extension) do
-        def around_hook(ctx) = nil
+        def initialize = around_hook :hook
+        def hook(ctx) = nil
       end
       log = []
       ctx = field_ctx.new(blueprint.new, serializer.default_fields, {}, {}, { foo: 'Foo' }, field, 42)

--- a/spec/extensions/multi_json_spec.rb
+++ b/spec/extensions/multi_json_spec.rb
@@ -12,7 +12,7 @@ describe Blueprinter::Extensions::MultiJson do
   it 'renders JSON' do
     fields = blueprint.reflections[:default].ordered
     ctx = Blueprinter::V2::Context::Result.new(blueprint, fields, {}, { id: 42, name: 'Foo' }, :json)
-    res = described_class.new.around_result(ctx, &:object)
+    res = described_class.new.serialize(ctx, &:object)
     expect(res.value).to eq '{"id":42,"name":"Foo"}'
   end
 

--- a/spec/extensions/open_telemetry_spec.rb
+++ b/spec/extensions/open_telemetry_spec.rb
@@ -13,14 +13,18 @@ describe Blueprinter::Extensions::OpenTelemetry do
     Class.new(Blueprinter::Extension) do
       def self.name = 'MetaExt'
 
-      def initialize(log) = @log = log
+      def initialize(log)
+        @log = log
+        around_object_value :log_object_value
+        around_hook :log_hook
+      end
 
-      def around_object_value(ctx)
+      def log_object_value(ctx)
         @log << 'around_object_value'
         yield ctx
       end
 
-      def around_hook(ctx)
+      def log_hook(ctx)
         @log << "around_hook(#{ctx.extension.class.name}##{ctx.hook}): A"
         yield
         @log << "around_hook(#{ctx.extension.class.name}##{ctx.hook}): B"
@@ -32,7 +36,7 @@ describe Blueprinter::Extensions::OpenTelemetry do
     ctx = prepare(blueprint, {}, Blueprinter::V2::Context::Object, { foo_obj: { name: 'Bar' } })
     expect_any_instance_of(OpenTelemetry::Internal::ProxyTracer).
       to receive(:in_span).with('blueprinter.object', attributes: { 'blueprint' => ctx.blueprint.class.to_s }.merge(attributes)).and_call_original
-    called = subject.around_serialize_object(ctx) { :true }
+    called = subject.trace_object(ctx) { :true }
     expect(called).to eq :true
   end
 
@@ -40,16 +44,16 @@ describe Blueprinter::Extensions::OpenTelemetry do
     ctx = prepare(blueprint, {}, Blueprinter::V2::Context::Object, { foos: [{ name: 'Bar' }] })
     expect_any_instance_of(OpenTelemetry::Internal::ProxyTracer).
       to receive(:in_span).with('blueprinter.collection', attributes: { 'blueprint' => ctx.blueprint.class.to_s }.merge(attributes)).and_call_original
-    called = subject.around_serialize_collection(ctx) { :true }
+    called = subject.trace_collection(ctx) { :true }
     expect(called).to eq :true
   end
 
   it 'creates a blueprinter.extension span with an extension' do
     ctx = prepare(blueprint, {}, Blueprinter::V2::Context::Object, { foos: [{ name: 'Bar' }] })
     expect_any_instance_of(OpenTelemetry::Internal::ProxyTracer).
-      to receive(:in_span).with('blueprinter.extension', attributes: { extension: 'MetaExt', hook: :around_field_value }.merge(attributes)).and_call_original
-    hook_ctx = Blueprinter::V2::Context::Hook.new(ctx.blueprint, [], ctx.options, meta_extension.new([]), :around_field_value)
-    called = subject.around_hook(hook_ctx) { :true }
+      to receive(:in_span).with('blueprinter.extension', attributes: { extension: 'MetaExt', method: :test, hook: :around_field_value }.merge(attributes)).and_call_original
+    hook_ctx = Blueprinter::V2::Context::Hook.new(ctx.blueprint, [], ctx.options, meta_extension.new([]), :around_field_value, :test)
+    called = subject.trace_hook(hook_ctx) { :true }
     expect(called).to eq :true
   end
 
@@ -60,14 +64,24 @@ describe Blueprinter::Extensions::OpenTelemetry do
     sub_blueprint.add subject, meta_ext
     attributes = { 'library.name' => 'Blueprinter', 'library.version' => Blueprinter::VERSION }
     object = { foo: 'Foo', foo_obj: { name: 'Bar1' }, foos: [{ name: 'Bar2' }] }
+
     expect_any_instance_of(OpenTelemetry::Internal::ProxyTracer).
       to receive(:in_span).with('blueprinter.object', attributes: { 'blueprint' => blueprint.to_s }.merge(attributes)).and_call_original
     expect_any_instance_of(OpenTelemetry::Internal::ProxyTracer).
       to receive(:in_span).with('blueprinter.object', attributes: { 'blueprint' => sub_blueprint.to_s }.merge(attributes)).twice.and_call_original
     expect_any_instance_of(OpenTelemetry::Internal::ProxyTracer).
-      to receive(:in_span).with('blueprinter.extension', attributes: { extension: 'MetaExt', hook: :around_object_value }.merge(attributes)).twice.and_call_original
+      to receive(:in_span).with('blueprinter.extension', attributes: { extension: 'MetaExt', method: :log_object_value, hook: :around_object_value }.merge(attributes)).twice.and_call_original
     expect_any_instance_of(OpenTelemetry::Internal::ProxyTracer).
       to receive(:in_span).with('blueprinter.collection', attributes: { 'blueprint' => sub_blueprint.to_s }.merge(attributes)).twice.and_call_original
+
     blueprint.render(object).to_hash
+    expect(log).to eq [
+      'around_hook(MetaExt#around_object_value): A',
+      'around_object_value',
+      'around_hook(MetaExt#around_object_value): B',
+      'around_hook(MetaExt#around_object_value): A',
+      'around_object_value',
+      'around_hook(MetaExt#around_object_value): B'
+    ]
   end
 end

--- a/spec/v2/extension_dsl_spec.rb
+++ b/spec/v2/extension_dsl_spec.rb
@@ -7,10 +7,12 @@ describe "Blueprinter::V2 Extension DSL" do
       def self.blueprint_name = "NameBlueprint"
       field :name
       extension do
-        def around_field_value(ctx) = yield(ctx).upcase
+        def initialize = around_field_value :field_value
+        def field_value(ctx) = yield(ctx).upcase
       end
       extension do
-        def around_serialize_object(ctx)
+        def initialize = around_serialize_object :serialize_object
+        def serialize_object(ctx)
           res = yield ctx
           { data: res }
         end

--- a/spec/v2/extensions/core/format_spec.rb
+++ b/spec/v2/extensions/core/format_spec.rb
@@ -13,20 +13,20 @@ describe Blueprinter::V2::Extensions::Core::Format do
 
   it 'outputs a Hash' do
     ctx = context.new(blueprint.new, [], {}, { 'name' => 'Foo' }, :hash)
-    result = subject.around_result(ctx) { |ctx| ctx.object }
+    result = subject.format(ctx) { |ctx| ctx.object }
     expect(result).to eq ctx.object
   end
 
   it 'outputs json' do
     ctx = context.new(blueprint.new, [], {}, { 'name' => 'Foo' }, :json)
-    result = subject.around_result(ctx) { |ctx| ctx.object }
+    result = subject.format(ctx) { |ctx| ctx.object }
     expect(result.value).to eq ctx.object.to_json
   end
 
   it 'raises an exception for an unsupported format' do
     ctx = context.new(blueprint.new, [], {}, { 'name' => 'Foo' }, :yaml)
     expect do
-      subject.around_result(ctx) { |ctx| ctx.object }
+      subject.format(ctx) { |ctx| ctx.object }
     end.to raise_error(Blueprinter::BlueprinterError, 'Unrecognized serialization format `:yaml`')
   end
 end

--- a/spec/v2/render_spec.rb
+++ b/spec/v2/render_spec.rb
@@ -112,7 +112,8 @@ describe Blueprinter::V2::Render do
   context 'around_result' do
     it 'runs around the entire result' do
       widget_blueprint.extension do
-        def around_result(ctx)
+        def initialize = around_result :hook
+        def hook(ctx)
           result = yield ctx
           result.merge({ foo: 'bar' })
         end
@@ -130,7 +131,8 @@ describe Blueprinter::V2::Render do
 
     it 'can change the blueprint (class)' do
       widget_blueprint.extension do
-        def around_result(ctx)
+        def initialize = around_result :hook
+        def hook(ctx)
           ctx.blueprint = Class.new(Blueprinter::V2::Base) { field :name }
           yield ctx
         end
@@ -143,7 +145,8 @@ describe Blueprinter::V2::Render do
 
     it 'can change the blueprint (instance)' do
       widget_blueprint.extension do
-        def around_result(ctx)
+        def initialize = around_result :hook
+        def hook(ctx)
           ctx.blueprint = Class.new(Blueprinter::V2::Base) { field :name }.new
           yield ctx
         end
@@ -156,7 +159,8 @@ describe Blueprinter::V2::Render do
 
     it 'can change the object' do
       widget_blueprint.extension do
-        def around_result(ctx)
+        def initialize = around_result :hook
+        def hook(ctx)
           ctx.object = ctx.object.merge({ name: 'Bar' })
           yield ctx
         end
@@ -173,7 +177,8 @@ describe Blueprinter::V2::Render do
 
     it 'can change the object (different blueprint)' do
       widget_blueprint.extension do
-        def around_result(ctx)
+        def initialize = around_result :hook
+        def hook(ctx)
           ctx.blueprint = Class.new(Blueprinter::V2::Base) { field :name }
           ctx.object = ctx.object.merge({ name: 'Bar' })
           yield ctx
@@ -187,14 +192,16 @@ describe Blueprinter::V2::Render do
 
     it 'can change the options' do
       widget_blueprint.extension do
-        def around_result(ctx)
+        def initialize = around_result :hook
+        def hook(ctx)
           num = ctx.options[:num] || 0
           ctx.options = ctx.options.merge({ num: num + 1 })
           yield ctx
         end
       end
       widget_blueprint.extension do
-        def around_result(ctx)
+        def initialize = around_result :hook
+        def hook(ctx)
           res = yield ctx
           res.merge({ num: ctx.options[:num] })
         end
@@ -212,7 +219,8 @@ describe Blueprinter::V2::Render do
 
     it 'can change the options (different blueprint)' do
       widget_blueprint.extension do
-        def around_result(ctx)
+        def initialize = around_result :hook
+        def hook(ctx)
           num = ctx.options[:num] || 0
           ctx.options = ctx.options.merge({ num: num + 1 })
           ctx.blueprint = Class.new(Blueprinter::V2::Base) do
@@ -231,7 +239,8 @@ describe Blueprinter::V2::Render do
 
     it 'can change the format' do
       widget_blueprint.extension do
-        def around_result(ctx)
+        def initialize = around_result :hook
+        def hook(ctx)
           ctx.format = :yaml
           yield ctx
         end
@@ -244,7 +253,8 @@ describe Blueprinter::V2::Render do
 
     it 'can change the format (different blueprint)' do
       widget_blueprint.extension do
-        def around_result(ctx)
+        def initialize = around_result :hook
+        def hook(ctx)
           ctx.format = :yaml
           ctx.blueprint = Class.new(Blueprinter::V2::Base) { field :name }
           yield ctx
@@ -258,7 +268,8 @@ describe Blueprinter::V2::Render do
 
     it 'can output a custom format' do
       widget_blueprint.extension do
-        def around_result(ctx)
+        def initialize = around_result :hook
+        def hook(ctx)
           case ctx.format
           when :yaml
             result = yield ctx
@@ -300,40 +311,49 @@ describe Blueprinter::V2::Render do
       it 'uses the same context store throughout' do
         log = []
         ext = Class.new(Blueprinter::Extension) do
-          def initialize(log) = @log = log
+          def initialize(log)
+            @log = log
+            around_result :around_result_hook
+            around_blueprint_init :around_blueprint_init_hook
+            around_serialize_object :around_serialize_object_hook
+            around_serialize_collection :around_serialize_collection_hook
+            around_field_value :around_field_value_hook
+            around_object_value :around_object_value_hook
+            around_collection_value :around_collection_value_hook
+          end
 
-          def around_result(ctx)
+          def around_result_hook(ctx)
             ctx.store[:log] = @log
             ctx.store[:log] << "around_result (#{ctx.blueprint})"
             yield ctx
           end
 
-          def around_blueprint_init(ctx)
+          def around_blueprint_init_hook(ctx)
             ctx.store[:log] << "around_blueprint_init (#{ctx.blueprint})"
             yield ctx
           end
 
-          def around_serialize_object(ctx)
+          def around_serialize_object_hook(ctx)
             ctx.store[:log] << "around_serialize_object (#{ctx.blueprint})"
             yield ctx
           end
 
-          def around_serialize_collection(ctx)
+          def around_serialize_collection_hook(ctx)
             ctx.store[:log] << "around_serialize_collection (#{ctx.blueprint})"
             yield ctx
           end
 
-          def around_field_value(ctx)
+          def around_field_value_hook(ctx)
             ctx.store[:log] << "around_field_value (#{ctx.blueprint})"
             yield ctx
           end
 
-          def around_object_value(ctx)
+          def around_object_value_hook(ctx)
             ctx.store[:log] << "around_object_value (#{ctx.blueprint})"
             yield ctx
           end
 
-          def around_collection_value(ctx)
+          def around_collection_value_hook(ctx)
             ctx.store[:log] << "around_collection_value (#{ctx.blueprint})"
             yield ctx
           end

--- a/spec/v2/serializer_spec.rb
+++ b/spec/v2/serializer_spec.rb
@@ -53,24 +53,30 @@ describe Blueprinter::V2::Serializer do
     let(:name_of_extractor) do
       test = self
       Class.new(Blueprinter::Extension) do
-        def initialize(prefix: 'Name') = @tmp_prefix = prefix
+        def initialize(prefix: 'Name')
+          @tmp_prefix = prefix
+          around_blueprint_init :around_blueprint_init_hook
+          around_field_value :around_field_value_hook
+          around_object_value :around_object_value_hook
+          around_collection_value :around_collection_value_hook
+        end
 
-        def around_blueprint_init(ctx)
+        def around_blueprint_init_hook(ctx)
           @prefix = @tmp_prefix
           yield ctx
         end
 
-        def around_field_value(ctx)
+        def around_field_value_hook(ctx)
           name = ctx.object.fetch(ctx.field.source)
           "#{@prefix} of #{name}"
         end
 
-        def around_object_value(ctx)
+        def around_object_value_hook(ctx)
           obj = ctx.object.fetch(ctx.field.source)
           { name: "#{@prefix} of #{obj[:name]}" }
         end
 
-        def around_collection_value(ctx)
+        def around_collection_value_hook(ctx)
           collection = ctx.object.fetch(ctx.field.source)
           collection.each_with_index.map { |_, i| { num: i + 1 } }
         end
@@ -201,10 +207,12 @@ describe Blueprinter::V2::Serializer do
 
   it 'enables custom extensions' do
     ext1 = Class.new(Blueprinter::Extension) do
-      def around_serialize_object(ctx) = yield ctx
+      def initialize = around_serialize_object :hook
+      def hook(ctx) = yield ctx
     end
     ext2 = Class.new(Blueprinter::Extension) do
-      def around_serialize_collection(ctx) = yield ctx
+      def initialize = around_serialize_collection :hook
+      def hook(ctx) = yield ctx
     end
     category_blueprint.add ext1.new, ext2.new
     serializer = category_blueprint.serializer
@@ -226,13 +234,15 @@ describe Blueprinter::V2::Serializer do
 
   it 'calls nested around_field_value hooks, then formatters' do
     ext1 = Class.new(Blueprinter::Extension) do
-      def around_field_value(ctx)
+      def initialize = around_field_value :hook
+      def hook(ctx)
         value = yield ctx
         value == '?' ? skip! : value
       end
     end
     ext2 = Class.new(Blueprinter::Extension) do
-      def around_field_value(ctx)
+      def initialize = around_field_value :hook
+      def hook(ctx)
         value = yield ctx
         value.is_a?(Date) ? value + 10 : '?'
       end
@@ -250,13 +260,15 @@ describe Blueprinter::V2::Serializer do
 
   it 'calls nested around_object_value hooks' do
     ext1 = Class.new(Blueprinter::Extension) do
-      def around_object_value(ctx)
+      def initialize = around_object_value :hook
+      def hook(ctx)
         value = yield ctx
         value[:name] == 'Bar' ? skip! : value
       end
     end
     ext2 = Class.new(Blueprinter::Extension) do
-      def around_object_value(_ctx)
+      def initialize = around_object_value :hook
+      def hook(_ctx)
         { name: 'Bar' }
       end
     end
@@ -269,16 +281,19 @@ describe Blueprinter::V2::Serializer do
 
   it 'calls nested around_collection_value hooks' do
     ext1 = Class.new(Blueprinter::Extension) do
-      def around_collection_value(ctx) = yield(ctx) << { num: 43 }
+      def initialize = around_collection_value :hook
+      def hook(ctx) = yield(ctx) << { num: 43 }
     end
     ext2 = Class.new(Blueprinter::Extension) do
-      def around_collection_value(ctx)
+      def initialize = around_collection_value :hook
+      def hook(ctx)
         value = yield ctx
         value.empty? ? skip! : value
       end
     end
     ext3 = Class.new(Blueprinter::Extension) do
-      def around_collection_value(ctx) = yield(ctx)[1..]
+      def initialize = around_collection_value :hook
+      def hook(ctx) = yield(ctx)[1..]
     end
     widget_blueprint.add ext1.new, ext2.new, ext3.new
 
@@ -333,29 +348,33 @@ describe Blueprinter::V2::Serializer do
     ext = Class.new(Blueprinter::Extension) do
       def initialize(log)
         @log = log
+        around_blueprint_init :around_blueprint_init_hook
+        around_serialize_object :around_serialize_object_hook
+        around_serialize_collection :around_serialize_collection_hook
+        around_blueprint :around_blueprint_hook
       end
 
-      def around_blueprint_init(ctx)
+      def around_blueprint_init_hook(ctx)
         @log << "around_blueprint_init (#{ctx.blueprint.class}): a"
         yield ctx
         @log << "around_blueprint_init (#{ctx.blueprint.class}): b"
       end
 
-      def around_serialize_object(ctx)
+      def around_serialize_object_hook(ctx)
         @log << "around_serialize_object (#{ctx.object[:name]}): a"
         res = yield ctx
         @log << "around_serialize_object (#{ctx.object[:name]}): b"
         res
       end
 
-      def around_serialize_collection(ctx)
+      def around_serialize_collection_hook(ctx)
         @log << "around_serialize_collection (#{ctx.object.size}): a"
         res = yield ctx
         @log << "around_serialize_collection (#{ctx.object.size}): b"
         res
       end
 
-      def around_blueprint(ctx)
+      def around_blueprint_hook(ctx)
         @log << "around_blueprint (#{ctx.object[:name]}): a"
         res = yield ctx
         @log << "around_blueprint (#{ctx.object[:name]}): b"
@@ -415,8 +434,12 @@ describe Blueprinter::V2::Serializer do
   it 'only runs around_blueprint_init once per blueprint' do
     log = []
     ext = Class.new(Blueprinter::Extension) do
-      def initialize(log) = @log = log
-      def around_blueprint_init(ctx)
+      def initialize(log)
+        @log = log
+        around_blueprint_init :hook
+      end
+
+      def hook(ctx)
         @log << "around_blueprint_init (#{ctx.blueprint.class})"
         yield ctx
       end
@@ -443,7 +466,8 @@ describe Blueprinter::V2::Serializer do
 
   it "raises if around_blueprint_init doesn't yield" do
     ext = Class.new(Blueprinter::Extension) do
-      def around_blueprint_init(ctx) = true
+      def initialize = around_blueprint_init :hook
+      def hook(ctx) = true
     end
     application_blueprint.add ext.new
 
@@ -454,7 +478,8 @@ describe Blueprinter::V2::Serializer do
 
   it "allows around_blueprint_init to modify blueprint options and fields" do
     ext = Class.new(Blueprinter::Extension) do
-      def around_blueprint_init(ctx)
+      def initialize = around_blueprint_init :hook
+      def hook(ctx)
         ctx.blueprint.options[:exclude_if_nil] = true
         ctx.fields.sort_by!(&:name)
         ctx.fields.find { |f| f.name == :description }.options[:exclude_if_nil] = false
@@ -526,9 +551,13 @@ describe Blueprinter::V2::Serializer do
 
   it 'passes objects information about the parent' do
     ext = Class.new(Blueprinter::Extension) do
-      def initialize(log) = @log = log
+      def initialize(log)
+        @log = log
+        around_serialize_object :around_serialize_object_hook
+        around_serialize_collection :around_serialize_collection_hook
+      end
 
-      def around_serialize_object(ctx)
+      def around_serialize_object_hook(ctx)
         if ctx.parent
           @log << "Object Parent Blueprint: #{ctx.parent.blueprint}"
           @log << "Object Parent field: #{ctx.parent.field.name}"
@@ -537,7 +566,7 @@ describe Blueprinter::V2::Serializer do
         yield ctx
       end
 
-      def around_serialize_collection(ctx)
+      def around_serialize_collection_hook(ctx)
         if ctx.parent
           @log << "Collection Parent Blueprint: #{ctx.parent.blueprint}"
           @log << "Collection Parent field: #{ctx.parent.field.name}"


### PR DESCRIPTION
Require extensions to register hooks in the initializer (instead of defining magic `around_*` methods). This allows extensions to enable or disable certain hooks based on args passed to the constructor.

```ruby
class MyExtension < Blueprinter::Extension
  def initialize
    around_blueprint :transform
  end

  def transform(ctx)
    hash = yield ctx
    # transform hash
    hash
  end
end
```